### PR TITLE
DHCPv6: add support for stateful DHCPv6 (RFC 8415)

### DIFF
--- a/src/core/ipv6/dhcp6.c
+++ b/src/core/ipv6/dhcp6.c
@@ -284,6 +284,89 @@ dhcp6_stateful_enabled(struct dhcp6 *dhcp6)
   return 1;
 }*/
 
+/**
+ * Create a DHCPv6 request, fill in common headers
+ *
+ * @param netif the netif under DHCPv6 control
+ * @param dhcp6 dhcp6 control struct
+ * @param message_type message type of the request
+ * @param opt_len_alloc option length to allocate
+ * @param options_out_len option length on exit
+ * @return a pbuf for the message
+ */
+static struct pbuf *
+dhcp6_create_msg(struct netif *netif, struct dhcp6 *dhcp6, u8_t message_type,
+                 u16_t opt_len_alloc, u16_t *options_out_len)
+{
+  struct pbuf *p_out;
+  struct dhcp6_msg *msg_out;
+
+  LWIP_ERROR("dhcp6_create_msg: netif != NULL", (netif != NULL), return NULL;);
+  LWIP_ERROR("dhcp6_create_msg: dhcp6 != NULL", (dhcp6 != NULL), return NULL;);
+  p_out = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcp6_msg) + opt_len_alloc, PBUF_RAM);
+  if (p_out == NULL) {
+    LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_SERIOUS,
+                ("dhcp6_create_msg(): could not allocate pbuf\n"));
+    return NULL;
+  }
+  LWIP_ASSERT("dhcp6_create_msg: check that first pbuf can hold struct dhcp6_msg",
+              (p_out->len >= sizeof(struct dhcp6_msg) + opt_len_alloc));
+
+  /* @todo: limit new xid for certain message types? */
+  /* reuse transaction identifier in retransmissions */
+  if (dhcp6->tries == 0) {
+    dhcp6->xid = LWIP_RAND() & 0xFFFFFF;
+  }
+
+  LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE,
+              ("transaction id xid(%"X32_F")\n", dhcp6->xid));
+
+  msg_out = (struct dhcp6_msg *)p_out->payload;
+  memset(msg_out, 0, sizeof(struct dhcp6_msg) + opt_len_alloc);
+
+  msg_out->msgtype = message_type;
+  msg_out->transaction_id[0] = (u8_t)(dhcp6->xid >> 16);
+  msg_out->transaction_id[1] = (u8_t)(dhcp6->xid >> 8);
+  msg_out->transaction_id[2] = (u8_t)dhcp6->xid;
+  *options_out_len = 0;
+  return p_out;
+}
+
+static u16_t
+dhcp6_option_short(u16_t options_out_len, u8_t *options, u16_t value)
+{
+  options[options_out_len++] = (u8_t)((value & 0xff00U) >> 8);
+  options[options_out_len++] = (u8_t) (value & 0x00ffU);
+  return options_out_len;
+}
+
+static u16_t
+dhcp6_option_optionrequest(u16_t options_out_len, u8_t *options, const u16_t *req_options,
+                           u16_t num_req_options, u16_t max_len)
+{
+  size_t i;
+  u16_t ret;
+
+  LWIP_ASSERT("dhcp6_option_optionrequest: options_out_len + sizeof(struct dhcp6_msg) + addlen <= max_len",
+    sizeof(struct dhcp6_msg) + options_out_len + 4U + (2U * num_req_options) <= max_len);
+  LWIP_UNUSED_ARG(max_len);
+
+  ret = dhcp6_option_short(options_out_len, options, DHCP6_OPTION_ORO);
+  ret = dhcp6_option_short(ret, options, 2 * num_req_options);
+  for (i = 0; i < num_req_options; i++) {
+    ret = dhcp6_option_short(ret, options, req_options[i]);
+  }
+  return ret;
+}
+
+/* All options are added, shrink the pbuf to the required size */
+static void
+dhcp6_msg_finalize(u16_t options_out_len, struct pbuf *p_out)
+{
+  /* shrink the pbuf to the actual content length */
+  pbuf_realloc(p_out, (u16_t)(sizeof(struct dhcp6_msg) + options_out_len));
+}
+
 static void
 dhcp6_set_req_timeout(struct dhcp6 *dhcp6, u16_t initial_rt, u16_t max_rt)
 {
@@ -380,90 +463,6 @@ dhcp6_disable(struct netif *netif)
     }
   }
 }
-
-/**
- * Create a DHCPv6 request, fill in common headers
- *
- * @param netif the netif under DHCPv6 control
- * @param dhcp6 dhcp6 control struct
- * @param message_type message type of the request
- * @param opt_len_alloc option length to allocate
- * @param options_out_len option length on exit
- * @return a pbuf for the message
- */
-static struct pbuf *
-dhcp6_create_msg(struct netif *netif, struct dhcp6 *dhcp6, u8_t message_type,
-                 u16_t opt_len_alloc, u16_t *options_out_len)
-{
-  struct pbuf *p_out;
-  struct dhcp6_msg *msg_out;
-
-  LWIP_ERROR("dhcp6_create_msg: netif != NULL", (netif != NULL), return NULL;);
-  LWIP_ERROR("dhcp6_create_msg: dhcp6 != NULL", (dhcp6 != NULL), return NULL;);
-  p_out = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcp6_msg) + opt_len_alloc, PBUF_RAM);
-  if (p_out == NULL) {
-    LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_SERIOUS,
-                ("dhcp6_create_msg(): could not allocate pbuf\n"));
-    return NULL;
-  }
-  LWIP_ASSERT("dhcp6_create_msg: check that first pbuf can hold struct dhcp6_msg",
-              (p_out->len >= sizeof(struct dhcp6_msg) + opt_len_alloc));
-
-  /* @todo: limit new xid for certain message types? */
-  /* reuse transaction identifier in retransmissions */
-  if (dhcp6->tries == 0) {
-    dhcp6->xid = LWIP_RAND() & 0xFFFFFF;
-  }
-
-  LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE,
-              ("transaction id xid(%"X32_F")\n", dhcp6->xid));
-
-  msg_out = (struct dhcp6_msg *)p_out->payload;
-  memset(msg_out, 0, sizeof(struct dhcp6_msg) + opt_len_alloc);
-
-  msg_out->msgtype = message_type;
-  msg_out->transaction_id[0] = (u8_t)(dhcp6->xid >> 16);
-  msg_out->transaction_id[1] = (u8_t)(dhcp6->xid >> 8);
-  msg_out->transaction_id[2] = (u8_t)dhcp6->xid;
-  *options_out_len = 0;
-  return p_out;
-}
-
-static u16_t
-dhcp6_option_short(u16_t options_out_len, u8_t *options, u16_t value)
-{
-  options[options_out_len++] = (u8_t)((value & 0xff00U) >> 8);
-  options[options_out_len++] = (u8_t) (value & 0x00ffU);
-  return options_out_len;
-}
-
-static u16_t
-dhcp6_option_optionrequest(u16_t options_out_len, u8_t *options, const u16_t *req_options,
-                           u16_t num_req_options, u16_t max_len)
-{
-  size_t i;
-  u16_t ret;
-
-  LWIP_ASSERT("dhcp6_option_optionrequest: options_out_len + sizeof(struct dhcp6_msg) + addlen <= max_len",
-    sizeof(struct dhcp6_msg) + options_out_len + 4U + (2U * num_req_options) <= max_len);
-  LWIP_UNUSED_ARG(max_len);
-
-  ret = dhcp6_option_short(options_out_len, options, DHCP6_OPTION_ORO);
-  ret = dhcp6_option_short(ret, options, 2 * num_req_options);
-  for (i = 0; i < num_req_options; i++) {
-    ret = dhcp6_option_short(ret, options, req_options[i]);
-  }
-  return ret;
-}
-
-/* All options are added, shrink the pbuf to the required size */
-static void
-dhcp6_msg_finalize(u16_t options_out_len, struct pbuf *p_out)
-{
-  /* shrink the pbuf to the actual content length */
-  pbuf_realloc(p_out, (u16_t)(sizeof(struct dhcp6_msg) + options_out_len));
-}
-
 
 #if LWIP_IPV6_DHCP6_STATELESS
 static void

--- a/src/include/lwip/dhcp6.h
+++ b/src/include/lwip/dhcp6.h
@@ -69,7 +69,22 @@ struct dhcp6
   /** #ticks with period DHCP6_TIMER_MSECS for request timeout */
   u16_t request_timeout;
 #if LWIP_IPV6_DHCP6_STATEFUL
-  /* @todo: add more members here to keep track of stateful DHCPv6 data, like lease times */
+  /** #ticks with period DHCP6_TIMER_MSECS since sending the first request packet */
+  u16_t elapsed_time;
+  /** server preference option value */
+  u8_t preference;
+  /** server DUID */
+  u8_t server_id[18];   /* identifiers longer than DUID-UUID are not supported */
+  /** server DUID length in bytes */
+  u8_t server_id_len;
+  /** Identity Association Identifier */
+  u32_t iaid;
+  /** IP address offered by server */
+  ip6_addr_t addr;
+  /** index of assigned IP address */
+  s8_t addr_idx;
+  /** timers for address lease */
+  u32_t t1, t2;
 #endif /* LWIP_IPV6_DHCP6_STATEFUL */
 };
 

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -2686,10 +2686,9 @@
 
 /**
  * LWIP_IPV6_DHCP6_STATEFUL==1: enable DHCPv6 stateful address autoconfiguration.
- * (not supported, yet!)
  */
 #if !defined LWIP_IPV6_DHCP6_STATEFUL || defined __DOXYGEN__
-#define LWIP_IPV6_DHCP6_STATEFUL        0
+#define LWIP_IPV6_DHCP6_STATEFUL        LWIP_IPV6_DHCP6
 #endif
 
 /**

--- a/src/include/lwip/prot/dhcp6.h
+++ b/src/include/lwip/prot/dhcp6.h
@@ -71,7 +71,12 @@ PACK_STRUCT_END
 typedef enum {
   DHCP6_STATE_OFF               = 0,
   DHCP6_STATE_STATELESS_IDLE    = 1,
-  DHCP6_STATE_REQUESTING_CONFIG = 2
+  DHCP6_STATE_REQUESTING_CONFIG = 2,
+  DHCP6_STATE_SOLICIT           = 3,
+  DHCP6_STATE_REQUESTING_ADDR   = 4,
+  DHCP6_STATE_STATEFUL_IDLE     = 5,
+  DHCP6_STATE_RENEW             = 6,
+  DHCP6_STATE_REBIND            = 7,
 } dhcp6_state_enum_t;
 
 /* DHCPv6 message types */


### PR DESCRIPTION
This adds supports for receiving IPv6 addresses from a DHCPv6 server. It implements sending of solicit, request, renew and rebind messages, and reception of advertise and reply messages.