### PR TITLE
TCP: add support for SYN cookies

### DIFF
--- a/src/core/tcp.c
+++ b/src/core/tcp.c
@@ -203,6 +203,10 @@ tcp_init(void)
 #ifdef LWIP_RAND
   tcp_port = TCP_ENSURE_LOCAL_PORT_RANGE(LWIP_RAND());
 #endif /* LWIP_RAND */
+#if TCP_LISTEN_BACKLOG
+  for (int i = 0; i < TCP_SYNCOOKIE_SECRET_SIZE / sizeof(u32_t); i++)
+    *(((u32_t *)tcp_syncookie_secret) + i) = LWIP_RAND();
+#endif
 }
 
 /** Free a tcp pcb */

--- a/src/core/tcp.c
+++ b/src/core/tcp.c
@@ -324,6 +324,9 @@ tcp_backlog_accepted(struct tcp_pcb *pcb)
       pcb->listener->accepts_pending--;
       tcp_clear_flags(pcb, TF_BACKLOGPEND);
     }
+  } else if ((pcb->state == SYN_RCVD) && (pcb->listener != NULL)) {
+    LWIP_ASSERT("syn_pending != 0", pcb->listener->syn_pending != 0);
+    pcb->listener->syn_pending--;
   }
 }
 #endif /* TCP_LISTEN_BACKLOG */
@@ -910,6 +913,7 @@ tcp_listen_with_backlog_and_err(struct tcp_pcb *pcb, u8_t backlog, err_t *err)
 #endif /* LWIP_CALLBACK_API */
 #if TCP_LISTEN_BACKLOG
   lpcb->accepts_pending = 0;
+  lpcb->syn_pending = 0;
   tcp_backlog_set(lpcb, backlog);
 #endif /* TCP_LISTEN_BACKLOG */
   TCP_REG(&tcp_listen_pcbs.pcbs, (struct tcp_pcb *)lpcb);

--- a/src/include/lwip/priv/tcp_priv.h
+++ b/src/include/lwip/priv/tcp_priv.h
@@ -154,6 +154,10 @@ err_t            tcp_process_refused_data(struct tcp_pcb *pcb);
 
 #define TCP_TCPLEN(seg) ((seg)->len + (((TCPH_FLAGS((seg)->tcphdr) & (TCP_FIN | TCP_SYN)) != 0) ? 1U : 0U))
 
+/* Syncookie secret size is chosen so that the size of the data on which the hash is calculated is a
+ * multiple of the block size of the hash function. */
+#define TCP_SYNCOOKIE_SECRET_SIZE   36
+
 /** Flags used on input processing, not on pcb->flags
 */
 #define TF_RESET     (u8_t)0x08U   /* Connection was reset. */
@@ -326,6 +330,7 @@ struct tcp_seg {
 extern struct tcp_pcb *tcp_input_pcb;
 extern u32_t tcp_ticks;
 extern u8_t tcp_active_pcbs_changed;
+extern u8_t tcp_syncookie_secret[TCP_SYNCOOKIE_SECRET_SIZE];
 
 /* The TCP PCB lists. */
 union tcp_listen_pcbs_t { /* List of all TCP PCBs in LISTEN state. */
@@ -465,6 +470,9 @@ err_t tcp_enqueue_flags(struct tcp_pcb *pcb, u8_t flags);
 void tcp_rexmit_seg(struct tcp_pcb *pcb, struct tcp_seg *seg);
 
 void tcp_rst(const struct tcp_pcb* pcb, u32_t seqno, u32_t ackno,
+       const ip_addr_t *local_ip, const ip_addr_t *remote_ip,
+       u16_t local_port, u16_t remote_port);
+void tcp_synack(const struct tcp_pcb_listen *pcb, u32_t seqno, u32_t ackno,
        const ip_addr_t *local_ip, const ip_addr_t *remote_ip,
        u16_t local_port, u16_t remote_port);
 

--- a/src/include/lwip/tcp.h
+++ b/src/include/lwip/tcp.h
@@ -234,6 +234,7 @@ struct tcp_pcb_listen {
 #if TCP_LISTEN_BACKLOG
   u8_t backlog;
   u8_t accepts_pending;
+  u8_t syn_pending;
 #endif /* TCP_LISTEN_BACKLOG */
 };
 

--- a/src/netif/ppp/polarssl/md5.c
+++ b/src/netif/ppp/polarssl/md5.c
@@ -39,7 +39,7 @@
  */
 
 #include "netif/ppp/ppp_opts.h"
-#if PPP_SUPPORT && LWIP_INCLUDED_POLARSSL_MD5
+#if LWIP_INCLUDED_POLARSSL_MD5
 
 #include "netif/ppp/polarssl/md5.h"
 
@@ -297,4 +297,4 @@ void md5( unsigned char *input, int ilen, unsigned char output[16] )
     md5_finish( &ctx, output );
 }
 
-#endif /* PPP_SUPPORT && LWIP_INCLUDED_POLARSSL_MD5 */
+#endif /* LWIP_INCLUDED_POLARSSL_MD5 */


### PR DESCRIPTION
This allows a TCP server to stay responsive when subject to "SYN flood" DoS attacks, without allocating memory for each SYN packet received from the attacker.
The hash function being used to calculate SYN cookie values is MD5.