### PR TITLE
tcp_update_rcv_ann_wnd(): fix tautological constant compare error

### DIFF
--- a/src/core/tcp.c
+++ b/src/core/tcp.c
@@ -939,11 +939,13 @@ u32_t
 tcp_update_rcv_ann_wnd(struct tcp_pcb *pcb)
 {
   u32_t new_right_edge;
+  u32_t wnd;
 
   LWIP_ASSERT("tcp_update_rcv_ann_wnd: invalid pcb", pcb != NULL);
   new_right_edge = pcb->rcv_nxt + pcb->rcv_wnd;
+  wnd = (TCP_WND / 2 >= 0xffff) ? pcb->mss : LWIP_MIN((TCP_WND / 2), pcb->mss);
 
-  if (TCP_SEQ_GEQ(new_right_edge, pcb->rcv_ann_right_edge + LWIP_MIN((TCP_WND / 2), pcb->mss))) {
+  if (TCP_SEQ_GEQ(new_right_edge, pcb->rcv_ann_right_edge + wnd)) {
     /* we can advertise more window */
     pcb->rcv_ann_wnd = pcb->rcv_wnd;
     return new_right_edge - pcb->rcv_ann_right_edge;


### PR DESCRIPTION
This compilation error ("result of comparison of constant 106496 with expression of type 'u16_t' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]") is output by Apple clang version 14.0.0 when the value of the TCP_WND constant is larger than or equal to 128 KB.