### PR TITLE
Raw API: implement multi-thread safety

### DIFF
--- a/src/apps/snmp/snmp_netconn.c
+++ b/src/apps/snmp/snmp_netconn.c
@@ -97,6 +97,7 @@ snmp_get_local_ip_for_dst(void *handle, const ip_addr_t *dst, ip_addr_t *result)
   struct netconn *conn = (struct netconn *)handle;
   struct netif *dst_if;
   const ip_addr_t *dst_ip;
+  u8_t result;
 
   LWIP_UNUSED_ARG(conn); /* unused in case of IPV4 only configuration */
 
@@ -104,10 +105,14 @@ snmp_get_local_ip_for_dst(void *handle, const ip_addr_t *dst, ip_addr_t *result)
 
   if ((dst_if != NULL) && (dst_ip != NULL)) {
     ip_addr_copy(*result, *dst_ip);
-    return 1;
+    result = 1;
   } else {
-    return 0;
+    result = 0;
   }
+  if (dst_if != NULL) {
+    netif_unref(dst_if);
+  }
+  return result;
 }
 
 /**

--- a/src/apps/snmp/snmp_raw.c
+++ b/src/apps/snmp/snmp_raw.c
@@ -65,6 +65,7 @@ snmp_get_local_ip_for_dst(void *handle, const ip_addr_t *dst, ip_addr_t *result)
   struct udp_pcb *udp_pcb = (struct udp_pcb *)handle;
   struct netif *dst_if;
   const ip_addr_t *dst_ip;
+  u8_t result;
 
   LWIP_UNUSED_ARG(udp_pcb); /* unused in case of IPV4 only configuration */
 
@@ -72,10 +73,14 @@ snmp_get_local_ip_for_dst(void *handle, const ip_addr_t *dst, ip_addr_t *result)
 
   if ((dst_if != NULL) && (dst_ip != NULL)) {
     ip_addr_copy(*result, *dst_ip);
-    return 1;
+    result = 1;
   } else {
-    return 0;
+    result = 0;
   }
+  if (dst_if != NULL) {
+    netif_unref(dst_if);
+  }
+  return result;
 }
 
 /**

--- a/src/core/dns.c
+++ b/src/core/dns.c
@@ -282,7 +282,7 @@ static err_t dns_lookup_local(const char *hostname, ip_addr_t *addr LWIP_DNS_ADD
 
 
 /* forward declarations */
-static void dns_recv(void *s, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port);
+static void dns_recv(void *s, struct udp_pcb *pcb, struct pbuf *p, struct ip_globals *ip_data, u16_t port);
 static void dns_check_entries(void);
 static void dns_call_found(u8_t idx, ip_addr_t *addr);
 
@@ -1167,7 +1167,7 @@ dns_correct_response(u8_t idx, u32_t ttl)
  * Receive input function for DNS response packets arriving for the dns UDP pcb.
  */
 static void
-dns_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port)
+dns_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, struct ip_globals *ip_data, u16_t port)
 {
   u8_t i;
   u16_t txid;
@@ -1218,7 +1218,7 @@ dns_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, 
         {
           /* Check whether response comes from the same network address to which the
              question was sent. (RFC 5452) */
-          if (!ip_addr_cmp(addr, &dns_servers[entry->server_idx])) {
+          if (!ip_addr_cmp(&ip_data->current_iphdr_src, &dns_servers[entry->server_idx])) {
             goto ignore_packet; /* ignore this packet */
           }
         }

--- a/src/core/ip.c
+++ b/src/core/ip.c
@@ -61,6 +61,7 @@
 #include "lwip/ip.h"
 
 /** Global data for both IPv4 and IPv6 */
+sys_lock_t ip_mutex;
 
 #if LWIP_IPV4 && LWIP_IPV6
 

--- a/src/core/ip.c
+++ b/src/core/ip.c
@@ -61,7 +61,6 @@
 #include "lwip/ip.h"
 
 /** Global data for both IPv4 and IPv6 */
-struct ip_globals ip_data;
 
 #if LWIP_IPV4 && LWIP_IPV6
 

--- a/src/core/ipv4/dhcp.c
+++ b/src/core/ipv4/dhcp.c
@@ -199,7 +199,7 @@ static err_t dhcp_reboot(struct netif *netif);
 static void dhcp_set_state(struct dhcp *dhcp, u8_t new_state);
 
 /* receive, unfold, parse and free incoming messages */
-static void dhcp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port);
+static void dhcp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, struct ip_globals *ip_data, u16_t port);
 
 /* set the DHCP timers */
 static void dhcp_timeout(struct netif *netif);
@@ -1751,10 +1751,11 @@ decode_next:
  * If an incoming DHCP message is in response to us, then trigger the state machine
  */
 static void
-dhcp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port)
+dhcp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, struct ip_globals *ip_data, u16_t port)
 {
-  struct netif *netif = ip_current_input_netif();
+  struct netif *netif = ip_data->current_input_netif;
   struct dhcp *dhcp = netif_dhcp_data(netif);
+  const ip_addr_t *addr = &ip_data->current_iphdr_src;
   struct dhcp_msg *reply_msg = (struct dhcp_msg *)p->payload;
   u8_t msg_type;
   u8_t i;

--- a/src/core/ipv4/icmp.c
+++ b/src/core/ipv4/icmp.c
@@ -397,6 +397,7 @@ icmp_send_response(struct pbuf *p, u8_t type, u8_t code)
 #endif
     ICMP_STATS_INC(icmp.xmit);
     ip4_output_if(q, NULL, &iphdr_src, ICMP_TTL, 0, IP_PROTO_ICMP, netif);
+    netif_unref(netif);
   }
   pbuf_free(q);
 }

--- a/src/core/ipv6/dhcp6.c
+++ b/src/core/ipv6/dhcp6.c
@@ -134,7 +134,7 @@ static u8_t dhcp6_pcb_refcount;
 
 
 /* receive, unfold, parse and free incoming messages */
-static void dhcp6_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port);
+static void dhcp6_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, struct ip_globals *ip_data, u16_t port);
 
 /** Ensure DHCP PCB is allocated and bound */
 static err_t
@@ -1157,10 +1157,11 @@ dhcp6_parse_reply(struct pbuf *p, struct dhcp6 *dhcp6)
 }
 
 static void
-dhcp6_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port)
+dhcp6_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, struct ip_globals *ip_data, u16_t port)
 {
-  struct netif *netif = ip_current_input_netif();
+  struct netif *netif = ip_data->current_input_netif;
   struct dhcp6 *dhcp6 = netif_dhcp6_data(netif);
+  const ip_addr_t *addr = &ip_data->current_iphdr_src;
   struct dhcp6_msg *reply_msg = (struct dhcp6_msg *)p->payload;
   u8_t msg_type;
   u32_t xid;

--- a/src/core/ipv6/icmp6.c
+++ b/src/core/ipv6/icmp6.c
@@ -372,6 +372,7 @@ icmp6_send_response_with_addrs(struct pbuf *p, u8_t code, u32_t data, u8_t type,
   }
   icmp6_send_response_with_addrs_and_netif(p, code, data, type, reply_src,
     reply_dest, netif);
+  netif_unref(netif);
 }
 
 /**

--- a/src/core/ipv6/nd6.c
+++ b/src/core/ipv6/nd6.c
@@ -87,9 +87,6 @@ u32_t retrans_timer = LWIP_ND6_RETRANS_TIMER; /* @todo implement this value in t
 static u8_t nd6_cached_neighbor_index;
 static netif_addr_idx_t nd6_cached_destination_index;
 
-/* Multicast address holder. */
-static ip6_addr_t multicast_address;
-
 static u8_t nd6_tmr_rs_reduction;
 
 /* Static buffer to parse RA packet options */
@@ -1186,6 +1183,7 @@ nd6_send_ns(struct netif *netif, const ip6_addr_t *target_addr, u8_t flags)
   struct pbuf *p;
   const ip6_addr_t *src_addr;
   u16_t lladdr_opt_len;
+  ip6_addr_t multicast_address;
 
   LWIP_ASSERT("target address is required", target_addr != NULL);
 
@@ -1262,6 +1260,7 @@ nd6_send_na(struct ip_globals *ip_data, const ip6_addr_t *target_addr, u8_t flag
   const ip6_addr_t *dest_addr;
   struct netif *netif;
   u16_t lladdr_opt_len;
+  ip6_addr_t multicast_address;
 
   LWIP_ASSERT("target address is required", target_addr != NULL);
 
@@ -1337,6 +1336,7 @@ nd6_send_rs(struct netif *netif)
   struct pbuf *p;
   const ip6_addr_t *src_addr;
   err_t err;
+  ip6_addr_t multicast_address;
   u16_t lladdr_opt_len = 0;
 
   /* Link-local source address, or unspecified address? */
@@ -2403,6 +2403,7 @@ void
 nd6_adjust_mld_membership(struct netif *netif, s8_t addr_idx, u8_t new_state)
 {
   u8_t old_state, old_member, new_member;
+  ip6_addr_t multicast_address;
 
   old_state = netif_ip6_addr_state(netif, addr_idx);
 

--- a/src/core/raw.c
+++ b/src/core/raw.c
@@ -355,6 +355,7 @@ raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr)
 {
   struct netif *netif;
   const ip_addr_t *src_ip;
+  err_t err;
 
   if ((pcb == NULL) || (ipaddr == NULL) || !IP_ADDR_PCB_VERSION_MATCH(pcb, ipaddr)) {
     return ERR_VAL;
@@ -392,7 +393,8 @@ raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr)
     src_ip = ip_netif_get_local_ip(netif, ipaddr);
 #if LWIP_IPV6
     if (src_ip == NULL) {
-      return ERR_RTE;
+      err = ERR_RTE;
+      goto out;
     }
 #endif /* LWIP_IPV6 */
   } else {
@@ -400,7 +402,10 @@ raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr)
     src_ip = &pcb->local_ip;
   }
 
-  return raw_sendto_if_src(pcb, p, ipaddr, netif, src_ip);
+  err = raw_sendto_if_src(pcb, p, ipaddr, netif, src_ip);
+out:
+  netif_unref(netif);
+  return err;
 }
 
 /**

--- a/src/core/tcp.c
+++ b/src/core/tcp.c
@@ -370,12 +370,7 @@ tcp_close_shutdown(struct tcp_pcb *pcb, u8_t rst_on_unacked_data)
       tcp_pcb_purge(pcb);
       TCP_RMV_ACTIVE(pcb);
       /* Deallocate the pcb since we already sent a RST for it */
-      if (tcp_input_pcb == pcb) {
-        /* prevent using a deallocated pcb: free it from tcp_input later */
-        tcp_trigger_input_pcb_close();
-      } else {
-        tcp_free(pcb);
-      }
+      tcp_free(pcb);
       return ERR_OK;
     }
   }

--- a/src/core/tcp_out.c
+++ b/src/core/tcp_out.c
@@ -1251,14 +1251,6 @@ tcp_output(struct tcp_pcb *pcb)
   LWIP_ASSERT("don't call tcp_output for listen-pcbs",
               pcb->state != LISTEN);
 
-  /* First, check if we are invoked by the TCP input processing
-     code. If so, we do not output anything. Instead, we rely on the
-     input processing code to call us when input processing is done
-     with. */
-  if (tcp_input_pcb == pcb) {
-    return ERR_OK;
-  }
-
   wnd = LWIP_MIN(pcb->snd_wnd, pcb->cwnd);
 
   seg = pcb->unsent;

--- a/src/include/lwip/icmp.h
+++ b/src/include/lwip/icmp.h
@@ -39,6 +39,7 @@
 
 #include "lwip/opt.h"
 #include "lwip/pbuf.h"
+#include "lwip/ip.h"
 #include "lwip/ip_addr.h"
 #include "lwip/netif.h"
 #include "lwip/prot/icmp.h"
@@ -77,7 +78,7 @@ enum icmp_te_type {
 
 #if LWIP_IPV4 && LWIP_ICMP /* don't build if not configured for use in lwipopts.h */
 
-void icmp_input(struct pbuf *p, struct netif *inp);
+void icmp_input(struct pbuf *p, struct ip_globals *ip_data);
 void icmp_dest_unreach(struct pbuf *p, enum icmp_dur_type t);
 void icmp_time_exceeded(struct pbuf *p, enum icmp_te_type t);
 
@@ -85,22 +86,22 @@ void icmp_time_exceeded(struct pbuf *p, enum icmp_te_type t);
 
 #if LWIP_IPV4 && LWIP_IPV6
 #if LWIP_ICMP && LWIP_ICMP6
-#define icmp_port_unreach(isipv6, pbuf) ((isipv6) ? \
-                                         icmp6_dest_unreach(pbuf, ICMP6_DUR_PORT) : \
+#define icmp_port_unreach(pbuf, ip_data) (ip_current_is_v6(ip_data) ? \
+                                         icmp6_dest_unreach(pbuf, ip_data, ICMP6_DUR_PORT) : \
                                          icmp_dest_unreach(pbuf, ICMP_DUR_PORT))
 #elif LWIP_ICMP
-#define icmp_port_unreach(isipv6, pbuf) do{ if(!(isipv6)) { icmp_dest_unreach(pbuf, ICMP_DUR_PORT);}}while(0)
+#define icmp_port_unreach(pbuf, ip_data) do{ if(!ip_current_is_v6(ip_data)) { icmp_dest_unreach(pbuf, ICMP_DUR_PORT);}}while(0)
 #elif LWIP_ICMP6
-#define icmp_port_unreach(isipv6, pbuf) do{ if(isipv6) { icmp6_dest_unreach(pbuf, ICMP6_DUR_PORT);}}while(0)
+#define icmp_port_unreach(pbuf, ip_data) do{ if(ip_current_is_v6(ip_data)) { icmp6_dest_unreach(pbuf, ip_data, ICMP6_DUR_PORT);}}while(0)
 #else
-#define icmp_port_unreach(isipv6, pbuf)
+#define icmp_port_unreach(pbuf, ip_data)
 #endif
 #elif LWIP_IPV6 && LWIP_ICMP6
-#define icmp_port_unreach(isipv6, pbuf) icmp6_dest_unreach(pbuf, ICMP6_DUR_PORT)
+#define icmp_port_unreach(pbuf, ip_data) icmp6_dest_unreach(pbuf, ICMP6_DUR_PORT)
 #elif LWIP_IPV4 && LWIP_ICMP
-#define icmp_port_unreach(isipv6, pbuf) icmp_dest_unreach(pbuf, ICMP_DUR_PORT)
+#define icmp_port_unreach(pbuf, ip_data) icmp_dest_unreach(pbuf, ICMP_DUR_PORT)
 #else /* (LWIP_IPV6 && LWIP_ICMP6) || (LWIP_IPV4 && LWIP_ICMP) */
-#define icmp_port_unreach(isipv6, pbuf)
+#define icmp_port_unreach(isipv6, pbuf, ip_data)
 #endif /* (LWIP_IPV6 && LWIP_ICMP6) || (LWIP_IPV4 && LWIP_ICMP) LWIP_IPV4*/
 
 #ifdef __cplusplus

--- a/src/include/lwip/icmp6.h
+++ b/src/include/lwip/icmp6.h
@@ -43,6 +43,7 @@
 
 #include "lwip/opt.h"
 #include "lwip/pbuf.h"
+#include "lwip/ip.h"
 #include "lwip/ip6_addr.h"
 #include "lwip/netif.h"
 #include "lwip/prot/icmp6.h"
@@ -53,13 +54,13 @@ extern "C" {
 
 #if LWIP_ICMP6 && LWIP_IPV6 /* don't build if not configured for use in lwipopts.h */
 
-void icmp6_input(struct pbuf *p, struct netif *inp);
-void icmp6_dest_unreach(struct pbuf *p, enum icmp6_dur_code c);
-void icmp6_packet_too_big(struct pbuf *p, u32_t mtu);
-void icmp6_time_exceeded(struct pbuf *p, enum icmp6_te_code c);
+void icmp6_input(struct pbuf *p, struct ip_globals *ip_data);
+void icmp6_dest_unreach(struct pbuf *p, struct ip_globals *ip_data, enum icmp6_dur_code c);
+void icmp6_packet_too_big(struct pbuf *p, struct ip_globals *ip_data, u32_t mtu);
+void icmp6_time_exceeded(struct pbuf *p, struct ip_globals *ip_data, enum icmp6_te_code c);
 void icmp6_time_exceeded_with_addrs(struct pbuf *p, enum icmp6_te_code c,
     const ip6_addr_t *src_addr, const ip6_addr_t *dest_addr);
-void icmp6_param_problem(struct pbuf *p, enum icmp6_pp_code c, const void *pointer);
+void icmp6_param_problem(struct pbuf *p, struct ip_globals *ip_data, enum icmp6_pp_code c, const void *pointer);
 
 #endif /* LWIP_ICMP6 && LWIP_IPV6 */
 

--- a/src/include/lwip/ip.h
+++ b/src/include/lwip/ip.h
@@ -74,6 +74,8 @@ extern "C" {
    changes to this common part are made in one location instead of
    having to change all PCB structs. */
 #define IP_PCB                             \
+  /* reference count */                    \
+  u32_t refcount;                          \
   /* ip addresses in network byte order */ \
   ip_addr_t local_ip;                      \
   ip_addr_t remote_ip;                     \
@@ -125,6 +127,7 @@ struct ip_globals
   /** Destination IP address of current_header */
   ip_addr_t current_iphdr_dest;
 };
+extern sys_lock_t ip_mutex;
 
 #if LWIP_IPV4 && LWIP_IPV6
 /** Get the IPv4 header of the current packet.
@@ -165,7 +168,7 @@ struct ip_globals
 /** Get the transport layer protocol */
 #define ip_current_header_proto(ip_data)    IPH_PROTO(ip4_current_header(ip_data))
 /** Get the transport layer header */
-#define ip_next_header_ptr(ip_data)         ((const void*)((const u8_t*)ip4_current_header(ip_data) + (ip_data)->current_ip_header_tot_len))
+#define ip_next_header_ptr(ip_data)         ((const void*)(((const u8_t*)ip4_current_header(ip_data)) + (ip_data)->current_ip_header_tot_len))
 /** Source IP4 address of current_header */
 #define ip4_current_src_addr(ip_data)       (&(ip_data)->current_iphdr_src)
 /** Destination IP4 address of current_header */

--- a/src/include/lwip/ip.h
+++ b/src/include/lwip/ip.h
@@ -125,93 +125,70 @@ struct ip_globals
   /** Destination IP address of current_header */
   ip_addr_t current_iphdr_dest;
 };
-extern struct ip_globals ip_data;
-
-
-/** Get the interface that accepted the current packet.
- * This may or may not be the receiving netif, depending on your netif/network setup.
- * This function must only be called from a receive callback (udp_recv,
- * raw_recv, tcp_accept). It will return NULL otherwise. */
-#define ip_current_netif()      (ip_data.current_netif)
-/** Get the interface that received the current packet.
- * This function must only be called from a receive callback (udp_recv,
- * raw_recv, tcp_accept). It will return NULL otherwise. */
-#define ip_current_input_netif() (ip_data.current_input_netif)
-/** Total header length of ip(6)_current_header() (i.e. after this, the UDP/TCP header starts) */
-#define ip_current_header_tot_len() (ip_data.current_ip_header_tot_len)
-/** Source IP address of current_header */
-#define ip_current_src_addr()   (&ip_data.current_iphdr_src)
-/** Destination IP address of current_header */
-#define ip_current_dest_addr()  (&ip_data.current_iphdr_dest)
 
 #if LWIP_IPV4 && LWIP_IPV6
 /** Get the IPv4 header of the current packet.
  * This function must only be called from a receive callback (udp_recv,
  * raw_recv, tcp_accept). It will return NULL otherwise. */
-#define ip4_current_header()     ip_data.current_ip4_header
+#define ip4_current_header(ip_data)         (ip_data)->current_ip4_header
 /** Get the IPv6 header of the current packet.
  * This function must only be called from a receive callback (udp_recv,
  * raw_recv, tcp_accept). It will return NULL otherwise. */
-#define ip6_current_header()      ((const struct ip6_hdr*)(ip_data.current_ip6_header))
+#define ip6_current_header(ip_data)         ((const struct ip6_hdr*)((ip_data)->current_ip6_header))
 /** Returns TRUE if the current IP input packet is IPv6, FALSE if it is IPv4 */
-#define ip_current_is_v6()        (ip6_current_header() != NULL)
+#define ip_current_is_v6(ip_data)           (ip6_current_header(ip_data) != NULL)
 /** Source IPv6 address of current_header */
-#define ip6_current_src_addr()    (ip_2_ip6(&ip_data.current_iphdr_src))
+#define ip6_current_src_addr(ip_data)       (ip_2_ip6(&(ip_data)->current_iphdr_src))
 /** Destination IPv6 address of current_header */
-#define ip6_current_dest_addr()   (ip_2_ip6(&ip_data.current_iphdr_dest))
+#define ip6_current_dest_addr(ip_data)      (ip_2_ip6(&(ip_data)->current_iphdr_dest))
 /** Get the transport layer protocol */
-#define ip_current_header_proto() (ip_current_is_v6() ? \
-                                   IP6H_NEXTH(ip6_current_header()) :\
-                                   IPH_PROTO(ip4_current_header()))
+#define ip_current_header_proto(ip_data)    (ip_current_is_v6(ip_data) ? \
+                                   IP6H_NEXTH(ip6_current_header(ip_data)) :\
+                                   IPH_PROTO(ip4_current_header(ip_data)))
 /** Get the transport layer header */
-#define ip_next_header_ptr()     ((const void*)((ip_current_is_v6() ? \
-  (const u8_t*)ip6_current_header() : (const u8_t*)ip4_current_header())  + ip_current_header_tot_len()))
+#define ip_next_header_ptr(ip_data)         ((const void*)((ip_current_is_v6(ip_data) ? \
+  (const u8_t*)ip6_current_header(ip_data) : (const u8_t*)ip4_current_header(ip_data)) + (ip_data)->current_ip_header_tot_len))
 
 /** Source IP4 address of current_header */
-#define ip4_current_src_addr()     (ip_2_ip4(&ip_data.current_iphdr_src))
+#define ip4_current_src_addr(ip_data)       (ip_2_ip4(&(ip_data)->current_iphdr_src))
 /** Destination IP4 address of current_header */
-#define ip4_current_dest_addr()    (ip_2_ip4(&ip_data.current_iphdr_dest))
+#define ip4_current_dest_addr(ip_data)      (ip_2_ip4(&(ip_data)->current_iphdr_dest))
 
 #elif LWIP_IPV4 /* LWIP_IPV4 && LWIP_IPV6 */
 
 /** Get the IPv4 header of the current packet.
  * This function must only be called from a receive callback (udp_recv,
  * raw_recv, tcp_accept). It will return NULL otherwise. */
-#define ip4_current_header()     ip_data.current_ip4_header
+#define ip4_current_header(ip_data)         (ip_data)->current_ip4_header
 /** Always returns FALSE when only supporting IPv4 only */
-#define ip_current_is_v6()        0
+#define ip_current_is_v6(ip_data)           0
 /** Get the transport layer protocol */
-#define ip_current_header_proto() IPH_PROTO(ip4_current_header())
+#define ip_current_header_proto(ip_data)    IPH_PROTO(ip4_current_header(ip_data))
 /** Get the transport layer header */
-#define ip_next_header_ptr()     ((const void*)((const u8_t*)ip4_current_header() + ip_current_header_tot_len()))
+#define ip_next_header_ptr(ip_data)         ((const void*)((const u8_t*)ip4_current_header(ip_data) + (ip_data)->current_ip_header_tot_len))
 /** Source IP4 address of current_header */
-#define ip4_current_src_addr()     (&ip_data.current_iphdr_src)
+#define ip4_current_src_addr(ip_data)       (&(ip_data)->current_iphdr_src)
 /** Destination IP4 address of current_header */
-#define ip4_current_dest_addr()    (&ip_data.current_iphdr_dest)
+#define ip4_current_dest_addr(ip_data)      (&(ip_data)->current_iphdr_dest)
 
 #elif LWIP_IPV6 /* LWIP_IPV4 && LWIP_IPV6 */
 
 /** Get the IPv6 header of the current packet.
  * This function must only be called from a receive callback (udp_recv,
  * raw_recv, tcp_accept). It will return NULL otherwise. */
-#define ip6_current_header()      ((const struct ip6_hdr*)(ip_data.current_ip6_header))
+#define ip6_current_header(ip_data)         ((const struct ip6_hdr*)((ip_data)->current_ip6_header))
 /** Always returns TRUE when only supporting IPv6 only */
-#define ip_current_is_v6()        1
+#define ip_current_is_v6(ip_data)           1
 /** Get the transport layer protocol */
-#define ip_current_header_proto() IP6H_NEXTH(ip6_current_header())
+#define ip_current_header_proto(ip_data)    IP6H_NEXTH(ip6_current_header(ip_data))
 /** Get the transport layer header */
-#define ip_next_header_ptr()     ((const void*)(((const u8_t*)ip6_current_header()) + ip_current_header_tot_len()))
+#define ip_next_header_ptr(ip_data)         ((const void*)(((const u8_t*)ip6_current_header(ip_data)) + (ip_data)->current_ip_header_tot_len))
 /** Source IP6 address of current_header */
-#define ip6_current_src_addr()    (&ip_data.current_iphdr_src)
+#define ip6_current_src_addr(ip_data)       (&(ip_data)->current_iphdr_src)
 /** Destination IP6 address of current_header */
-#define ip6_current_dest_addr()   (&ip_data.current_iphdr_dest)
+#define ip6_current_dest_addr(ip_data)      (&(ip_data)->current_iphdr_dest)
 
 #endif /* LWIP_IPV6 */
-
-/** Union source address of current_header */
-#define ip_current_src_addr()    (&ip_data.current_iphdr_src)
-/** Union destination address of current_header */
-#define ip_current_dest_addr()   (&ip_data.current_iphdr_dest)
 
 /** Gets an IP pcb option (SOF_* flags) */
 #define ip_get_option(pcb, opt)   ((pcb)->so_options & (opt))

--- a/src/include/lwip/ip6_frag.h
+++ b/src/include/lwip/ip6_frag.h
@@ -43,6 +43,7 @@
 
 #include "lwip/opt.h"
 #include "lwip/pbuf.h"
+#include "lwip/ip.h"
 #include "lwip/ip6_addr.h"
 #include "lwip/ip6.h"
 #include "lwip/netif.h"
@@ -113,7 +114,7 @@ struct ip6_reassdata {
 
 #define ip6_reass_init() /* Compatibility define */
 void ip6_reass_tmr(void);
-struct pbuf *ip6_reass(struct pbuf *p);
+struct pbuf *ip6_reass(struct pbuf *p, struct ip_globals *ip_data);
 
 #endif /* LWIP_IPV6 && LWIP_IPV6_REASS */
 

--- a/src/include/lwip/ip6_zone.h
+++ b/src/include/lwip/ip6_zone.h
@@ -250,6 +250,7 @@ enum lwip_ipv6_scope_type
   selected_netif = ip6_route((src), (dest)); \
   if (selected_netif != NULL) { \
     ip6_addr_assign_zone((dest), IP6_UNKNOWN, selected_netif); \
+    netif_unref(selected_netif); \
   } } while (0)
 
 /**

--- a/src/include/lwip/mld6.h
+++ b/src/include/lwip/mld6.h
@@ -48,6 +48,7 @@
 #if LWIP_IPV6_MLD && LWIP_IPV6  /* don't build if not configured for use in lwipopts.h */
 
 #include "lwip/pbuf.h"
+#include "lwip/ip.h"
 #include "lwip/netif.h"
 
 #ifdef __cplusplus
@@ -76,7 +77,7 @@ err_t  mld6_stop(struct netif *netif);
 void   mld6_report_groups(struct netif *netif);
 void   mld6_tmr(void);
 struct mld_group *mld6_lookfor_group(struct netif *ifp, const ip6_addr_t *addr);
-void   mld6_input(struct pbuf *p, struct netif *inp);
+void   mld6_input(struct pbuf *p, struct ip_globals *ip_data);
 err_t  mld6_joingroup(const ip6_addr_t *srcaddr, const ip6_addr_t *groupaddr);
 err_t  mld6_joingroup_netif(struct netif *netif, const ip6_addr_t *groupaddr);
 err_t  mld6_leavegroup(const ip6_addr_t *srcaddr, const ip6_addr_t *groupaddr);

--- a/src/include/lwip/nd6.h
+++ b/src/include/lwip/nd6.h
@@ -48,6 +48,7 @@
 
 #if LWIP_IPV6  /* don't build if not configured for use in lwipopts.h */
 
+#include "lwip/ip.h"
 #include "lwip/ip6_addr.h"
 #include "lwip/err.h"
 
@@ -67,7 +68,7 @@ struct pbuf;
 struct netif;
 
 void nd6_tmr(void);
-void nd6_input(struct pbuf *p, struct netif *inp);
+void nd6_input(struct pbuf *p, struct ip_globals *ip_data);
 void nd6_clear_destination_cache(void);
 struct netif *nd6_find_route(const ip6_addr_t *ip6addr);
 err_t nd6_get_next_hop_addr_or_queue(struct netif *netif, struct pbuf *q, const ip6_addr_t *ip6addr, const u8_t **hwaddrp);

--- a/src/include/lwip/priv/tcp_priv.h
+++ b/src/include/lwip/priv/tcp_priv.h
@@ -74,7 +74,7 @@ void             tcp_fasttmr (void);
 void             tcp_txnow   (void);
 
 /* Only used by IP to pass a TCP segment to TCP: */
-void             tcp_input   (struct pbuf *p, struct netif *inp);
+void             tcp_input   (struct pbuf *p, struct ip_globals *ip_data);
 /* Used within the TCP code only: */
 struct tcp_pcb * tcp_alloc   (u8_t prio);
 void             tcp_free    (struct tcp_pcb *pcb);

--- a/src/include/lwip/priv/tcp_priv.h
+++ b/src/include/lwip/priv/tcp_priv.h
@@ -327,7 +327,6 @@ struct tcp_seg {
 #endif /* LWIP_WND_SCALE */
 
 /* Global variables: */
-extern struct tcp_pcb *tcp_input_pcb;
 extern u32_t tcp_ticks;
 extern u8_t tcp_active_pcbs_changed;
 extern u8_t tcp_syncookie_secret[TCP_SYNCOOKIE_SECRET_SIZE];
@@ -481,7 +480,6 @@ u32_t tcp_next_iss(struct tcp_pcb *pcb);
 err_t tcp_keepalive(struct tcp_pcb *pcb);
 err_t tcp_split_unsent_seg(struct tcp_pcb *pcb, u16_t split);
 err_t tcp_zero_window_probe(struct tcp_pcb *pcb);
-void  tcp_trigger_input_pcb_close(void);
 
 #if TCP_CALCULATE_EFF_SEND_MSS
 u16_t tcp_eff_send_mss_netif(u16_t sendmss, struct netif *outif,

--- a/src/include/lwip/sys.h
+++ b/src/include/lwip/sys.h
@@ -552,6 +552,14 @@ void sys_arch_unprotect(sys_prot_t pval);
                               } while(0)
 #endif /* SYS_ARCH_LOCKED */
 
+#ifndef SYS_ARCH_LOCK_INIT
+
+#define SYS_ARCH_LOCK_INIT(l)
+#define SYS_ARCH_LOCK(l)
+#define SYS_ARCH_UNLOCK(l)
+#define SYS_ARCH_TRYLOCK(l)
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/include/lwip/tcp.h
+++ b/src/include/lwip/tcp.h
@@ -211,6 +211,7 @@ typedef u16_t tcpflags_t;
  */
 #define TCP_PCB_COMMON(type) \
   type *next; /* for the linked list */ \
+  sys_lock_t lock; \
   void *callback_arg; \
   TCP_PCB_EXTARGS \
   enum tcp_state state; /* TCP state */ \
@@ -420,6 +421,13 @@ void             tcp_err     (struct tcp_pcb *pcb, tcp_err_fn err);
 void             tcp_accept  (struct tcp_pcb *pcb, tcp_accept_fn accept);
 #endif /* LWIP_CALLBACK_API */
 void             tcp_poll    (struct tcp_pcb *pcb, tcp_poll_fn poll, u8_t interval);
+
+void             tcp_ref     (struct tcp_pcb *pcb);
+void             tcp_unref   (struct tcp_pcb *pcb);
+
+#define          tcp_lock(pcb)      SYS_ARCH_LOCK(&(pcb)->lock)
+#define          tcp_unlock(pcb)    SYS_ARCH_UNLOCK(&(pcb)->lock)
+#define          tcp_trylock(pcb)   SYS_ARCH_TRYLOCK(&(pcb)->lock)
 
 #define          tcp_set_flags(pcb, set_flags)     do { (pcb)->flags = (tcpflags_t)((pcb)->flags |  (set_flags)); } while(0)
 #define          tcp_clear_flags(pcb, clr_flags)   do { (pcb)->flags = (tcpflags_t)((pcb)->flags & (tcpflags_t)(~(clr_flags) & TCP_ALLFLAGS)); } while(0)

--- a/src/include/lwip/udp.h
+++ b/src/include/lwip/udp.h
@@ -152,6 +152,9 @@ err_t            udp_sendto_if_src_chksum(struct udp_pcb *pcb, struct pbuf *p,
                                  u8_t have_chksum, u16_t chksum, const ip_addr_t *src_ip);
 #endif /* LWIP_CHECKSUM_ON_COPY && CHECKSUM_GEN_UDP */
 
+void             udp_ref     (struct udp_pcb *pcb);
+void             udp_unref   (struct udp_pcb *pcb);
+
 #define          udp_flags(pcb) ((pcb)->flags)
 #define          udp_setflags(pcb, f)  ((pcb)->flags = (f))
 

--- a/src/include/lwip/udp.h
+++ b/src/include/lwip/udp.h
@@ -71,11 +71,11 @@ struct udp_pcb;
  * @param arg user supplied argument (udp_pcb.recv_arg)
  * @param pcb the udp_pcb which received data
  * @param p the packet buffer that was received
- * @param addr the remote IP address from which the packet was received
+ * @param ip_data data for the received packet computed by the IP input parser
  * @param port the remote port from which the packet was received
  */
 typedef void (*udp_recv_fn)(void *arg, struct udp_pcb *pcb, struct pbuf *p,
-    const ip_addr_t *addr, u16_t port);
+    struct ip_globals *ip_data, u16_t port);
 
 /** the UDP protocol control block */
 struct udp_pcb {
@@ -160,7 +160,7 @@ err_t            udp_sendto_if_src_chksum(struct udp_pcb *pcb, struct pbuf *p,
 #define          udp_is_flag_set(pcb, flag)        (((pcb)->flags & (flag)) != 0)
 
 /* The following functions are the lower layer interface to UDP. */
-void             udp_input      (struct pbuf *p, struct netif *inp);
+void             udp_input      (struct pbuf *p, struct ip_globals *ip_data);
 
 void             udp_init       (void);
 


### PR DESCRIPTION
This change set removes usage of global variables and adds locking and reference counting mechanisms to allow lwIP raw API functions and input callbacks to be invoked concurrently from multiple threads.
Several functions involved in processing input packets have been amended to take additional arguments instead of making use of global variables.
A new type (sys_lock_t) and a set of macros (such as SYS_ARCH_LOCK and SYS_ARCH_UNLOCK) are being added so that applications can provide a platform-specific locking implementation. Various subsystems in the network stack (DNS, IP, DHCP, ARP, MLD, ND, netif, TCP, UDP) now use locking to protect their global data structures from concurrent access.
The SYS_ARCH_INC() and SYS_ARCH_DEC() macros are used to atomically increment and decrement a variable, respectively.
The tcp_pcb structure is locked in order to protect from concurrent access the data representing a TCP connection state. In order to avoid deadlock, the lock of a TCP PCB must not be acquired while holding the global TCP lock (unless tcp_trylock() is used). Application callbacks registered on a TCP PCB are invoked with the PCB lock held; the application must acquire the PCB lock (via the tcp_lock() macro) before calling raw API functions (such as tcp_connect or tcp_output) on a TCP PCB.
The ip_pcb structure is reference-counted so that it is possible to process PCBs retrieved from global lists (e.g. the active TCP PCB list) without holding the lock that protects the lists, while at the same time allowing the application code to invoke APIs (such as tcp_close ot udp_remove) to deregister or deallocate a PCB.
Network interfaces are reference-counted so that it is possible to remove an interface while network packets are output on it; the netif_ref() and netif_unref() macros are provided to increment and decrement the interface reference count, respectively. The NETIF_FOREACH() macro is being replaced by a multithread-safe netif_iterate() function that takes a callback as argument and invokes the callback for each registered network interface. The netif_poll_all() function is being removed because a network interface cannot be polled while holding the netif lock (IP input parsing code invokes netif_iterate(), which needs to acquire the lock); the netif_poll_loopback() is now defined to poll the loopback interface, which is the only interface that needs to be polled. The netif_get_default() function is now used to retrieve the default network interface instead of accessing directly the netif_default global variable.