### PR TITLE
netif_add(): call netif_set_addr() without holding the netif lock

### DIFF
--- a/src/core/netif.c
+++ b/src/core/netif.c
@@ -387,10 +387,6 @@ netif_add(struct netif *netif,
   netif->loop_cnt_current = 0;
 #endif /* ENABLE_LOOPBACK && LWIP_LOOPBACK_MAX_PBUFS */
 
-#if LWIP_IPV4
-  netif_set_addr(netif, ipaddr, netmask, gw);
-#endif /* LWIP_IPV4 */
-
   /* call user specified initialization function for netif */
   if (init(netif) != ERR_OK) {
     return NULL;
@@ -437,6 +433,11 @@ netif_add(struct netif *netif,
   netif_list = netif;
 #endif /* "LWIP_SINGLE_NETIF */
   SYS_ARCH_UNLOCK(&netif_mutex);
+
+#if LWIP_IPV4
+  netif_set_addr(netif, ipaddr, netmask, gw);
+#endif /* LWIP_IPV4 */
+
   mib2_netif_added(netif);
 
 #if LWIP_IGMP


### PR DESCRIPTION
netif_set_addr() can trigger invocation of netif callbacks, thus it should be called without holding the netif lock, otherwise callbacks cannot call functions that acquire the lock (e.g. to check whether a given netif is the default network interface).