### PR TITLE
Eliminate deadlocks when calling tcp_pcbs_sane()

### DIFF
--- a/src/core/tcp.c
+++ b/src/core/tcp.c
@@ -2614,7 +2614,6 @@ s16_t
 tcp_pcbs_sane(void)
 {
   struct tcp_pcb *pcb;
-  SYS_ARCH_LOCK(&tcp_mutex);
   for (pcb = tcp_active_pcbs; pcb != NULL; pcb = pcb->next) {
     LWIP_ASSERT("tcp_pcbs_sane: active pcb->state != CLOSED", pcb->state != CLOSED);
     LWIP_ASSERT("tcp_pcbs_sane: active pcb->state != LISTEN", pcb->state != LISTEN);
@@ -2623,7 +2622,6 @@ tcp_pcbs_sane(void)
   for (pcb = tcp_tw_pcbs; pcb != NULL; pcb = pcb->next) {
     LWIP_ASSERT("tcp_pcbs_sane: tw pcb->state == TIME-WAIT", pcb->state == TIME_WAIT);
   }
-  SYS_ARCH_UNLOCK(&tcp_mutex);
   return 1;
 }
 #endif /* TCP_DEBUG */

--- a/src/core/tcp_in.c
+++ b/src/core/tcp_in.c
@@ -608,7 +608,11 @@ aborted:
     pbuf_free(p);
   }
 
+#if TCP_INPUT_DEBUG
+  SYS_ARCH_LOCK(&tcp_mutex);
   LWIP_ASSERT("tcp_input: tcp_pcbs_sane()", tcp_pcbs_sane());
+  SYS_ARCH_UNLOCK(&tcp_mutex);
+#endif
   PERF_STOP("tcp_input");
   return;
 dropped:


### PR DESCRIPTION
The tcp_pcbs_sane() function was locking the tcp_mutex in order to safely traverse the pcbs list, but it is sometimes called from other places such as tcp_pcb_remove(), which is called with that lock already held, thus creating a deadlock.

This change removes the locking from tcp_pcbs_sane and adds it to the one place where it is called without the lock held.