### PR TITLE
MLD6 timer: acquire MLD6 lock in netif callback function

### DIFF
--- a/src/core/ipv6/mld6.c
+++ b/src/core/ipv6/mld6.c
@@ -543,6 +543,7 @@ mld6_leavegroup_netif(struct netif *netif, const ip6_addr_t *groupaddr)
 
 static u8_t mld6_tmr_netif(struct netif *netif, void *priv)
 {
+  SYS_ARCH_LOCK(&mld6_mutex);
   struct mld_group *group = netif_mld6_data(netif);
 
   while (group != NULL) {
@@ -559,6 +560,7 @@ static u8_t mld6_tmr_netif(struct netif *netif, void *priv)
     }
     group = group->next;
   }
+  SYS_ARCH_UNLOCK(&mld6_mutex);
   return false;
 }
 
@@ -571,9 +573,7 @@ static u8_t mld6_tmr_netif(struct netif *netif, void *priv)
 void
 mld6_tmr(void)
 {
-  SYS_ARCH_LOCK(&mld6_mutex);
   netif_iterate(mld6_tmr_netif, NULL);
-  SYS_ARCH_UNLOCK(&mld6_mutex);
 }
 
 /**


### PR DESCRIPTION
If the MLD6 lock is acquired directly by mld6_tmr() before calling netif_iterate(), there is a lock inversion issue between the MLD6 and netif locks, which can cause a deadlock:
- CPU0 executes mld6_tmr() -> SYS_ARCH_LOCK(&mld6_mutex) -> netif_iterate() -> SYS_ARCH_LOCK(&netif_mutex)
- CPU1 executes nd6_tmr() -> netif_iterate() -> SYS_ARCH_LOCK(&netif_mutex) -> nd6_tmr_netif() -> netif_ip6_addr_set_state() -> nd6_adjust_mld_membership() -> mld6_joingroup_netif() -> SYS_ARCH_LOCK(&mld6_mutex)

This change fxes the above issue by moving the MLD6 lock acquisition from mld6_tmr() to mld6_tmr_netif(). This fixes the "context deadline exceeded" errors seen when executing the stressdisk E2E test on CircleCI.