### PR TITLE
ip4_input(): set ip_data.current_ip6_header to NULL

### DIFF
--- a/src/core/ipv4/ip4.c
+++ b/src/core/ipv4/ip4.c
@@ -751,6 +751,7 @@ ip4_input(struct pbuf *p, struct netif *inp)
 
   ip_data.current_netif = netif;
   ip_data.current_ip4_header = iphdr;
+  ip_data.current_ip6_header = NULL;
   ip_data.current_ip_header_tot_len = IPH_HL_BYTES(iphdr);
 
 #if LWIP_RAW


### PR DESCRIPTION
The current_ip6_header field of struct ip_globals is checked in the ip_current_is_v6() macro to determine whether an incoming IP packet is IPv6, thus this field should be set to NULL when a packet is IPv4.