### PR TITLE
tcp_recved(): change len parameter type from u16_t to tcpwnd_size_t

### DIFF
--- a/src/core/tcp.c
+++ b/src/core/tcp.c
@@ -1006,7 +1006,7 @@ tcp_update_rcv_ann_wnd(struct tcp_pcb *pcb)
  * @param len the amount of bytes that have been read by the application
  */
 void
-tcp_recved(struct tcp_pcb *pcb, u16_t len)
+tcp_recved(struct tcp_pcb *pcb, tcpwnd_size_t len)
 {
   u32_t wnd_inflation;
   tcpwnd_size_t rcv_wnd;
@@ -1019,7 +1019,7 @@ tcp_recved(struct tcp_pcb *pcb, u16_t len)
   LWIP_ASSERT("don't call tcp_recved for listen-pcbs",
               pcb->state != LISTEN);
 
-  rcv_wnd = (tcpwnd_size_t)(pcb->rcv_wnd + len);
+  rcv_wnd = pcb->rcv_wnd + len;
   if ((rcv_wnd > TCP_WND_MAX(pcb)) || (rcv_wnd < pcb->rcv_wnd)) {
     /* window got too big or tcpwnd_size_t overflow */
     LWIP_DEBUGF(TCP_DEBUG, ("tcp_recved: window got too big or tcpwnd_size_t overflow\n"));

--- a/src/include/lwip/tcp.h
+++ b/src/include/lwip/tcp.h
@@ -463,7 +463,7 @@ void             tcp_backlog_accepted(struct tcp_pcb* pcb);
 #endif /* TCP_LISTEN_BACKLOG */
 #define          tcp_accepted(pcb) do { LWIP_UNUSED_ARG(pcb); } while(0) /* compatibility define, not needed any more */
 
-void             tcp_recved  (struct tcp_pcb *pcb, u16_t len);
+void             tcp_recved  (struct tcp_pcb *pcb, tcpwnd_size_t len);
 err_t            tcp_bind    (struct tcp_pcb *pcb, const ip_addr_t *ipaddr,
                               u16_t port);
 void             tcp_bind_netif(struct tcp_pcb *pcb, const struct netif *netif);


### PR DESCRIPTION
When LWIP_WND_SCALE is enabled, the size of TCP data buffered at the receiver side can be larger than 64 KB, thus the tcp_recved() function can be called with a `len` argument larger than 64 KB. This change fixes a TCP performance issue that causes the window size of a TCP connection to be shrunk when the receiving application consumes more than 64 KB of data at a time.