### PR TITLE
Strings: remove unbounded memory access

### DIFF
--- a/src/api/err.c
+++ b/src/api/err.c
@@ -77,24 +77,24 @@ err_to_errno(err_t err)
 
 #ifdef LWIP_DEBUG
 
-static const char *err_strerr[] = {
-  "Ok.",                    /* ERR_OK          0  */
-  "Out of memory error.",   /* ERR_MEM        -1  */
-  "Buffer error.",          /* ERR_BUF        -2  */
-  "Timeout.",               /* ERR_TIMEOUT    -3  */
-  "Routing problem.",       /* ERR_RTE        -4  */
-  "Operation in progress.", /* ERR_INPROGRESS -5  */
-  "Illegal value.",         /* ERR_VAL        -6  */
-  "Operation would block.", /* ERR_WOULDBLOCK -7  */
-  "Address in use.",        /* ERR_USE        -8  */
-  "Already connecting.",    /* ERR_ALREADY    -9  */
-  "Already connected.",     /* ERR_ISCONN     -10 */
-  "Not connected.",         /* ERR_CONN       -11 */
-  "Low-level netif error.", /* ERR_IF         -12 */
-  "Connection aborted.",    /* ERR_ABRT       -13 */
-  "Connection reset.",      /* ERR_RST        -14 */
-  "Connection closed.",     /* ERR_CLSD       -15 */
-  "Illegal argument."       /* ERR_ARG        -16 */
+static const sstring err_strerr[] = {
+  ss_static_init("Ok."),                    /* ERR_OK          0  */
+  ss_static_init("Out of memory error."),   /* ERR_MEM        -1  */
+  ss_static_init("Buffer error."),          /* ERR_BUF        -2  */
+  ss_static_init("Timeout."),               /* ERR_TIMEOUT    -3  */
+  ss_static_init("Routing problem."),       /* ERR_RTE        -4  */
+  ss_static_init("Operation in progress."), /* ERR_INPROGRESS -5  */
+  ss_static_init("Illegal value."),         /* ERR_VAL        -6  */
+  ss_static_init("Operation would block."), /* ERR_WOULDBLOCK -7  */
+  ss_static_init("Address in use."),        /* ERR_USE        -8  */
+  ss_static_init("Already connecting."),    /* ERR_ALREADY    -9  */
+  ss_static_init("Already connected."),     /* ERR_ISCONN     -10 */
+  ss_static_init("Not connected."),         /* ERR_CONN       -11 */
+  ss_static_init("Low-level netif error."), /* ERR_IF         -12 */
+  ss_static_init("Connection aborted."),    /* ERR_ABRT       -13 */
+  ss_static_init("Connection reset."),      /* ERR_RST        -14 */
+  ss_static_init("Connection closed."),     /* ERR_CLSD       -15 */
+  ss_static_init("Illegal argument."),      /* ERR_ARG        -16 */
 };
 
 /**
@@ -103,11 +103,11 @@ static const char *err_strerr[] = {
  * @param err an lwip internal err_t
  * @return a string representation for err
  */
-const char *
+sstring
 lwip_strerr(err_t err)
 {
   if ((err > 0) || (-err >= (err_t)LWIP_ARRAYSIZE(err_strerr))) {
-    return "Unknown error.";
+    return ss("Unknown error.");
   }
   return err_strerr[-err];
 }

--- a/src/core/def.c
+++ b/src/core/def.c
@@ -95,29 +95,6 @@ lwip_htonl(u32_t n)
 
 #endif /* BYTE_ORDER == LITTLE_ENDIAN */
 
-#ifndef lwip_strnstr
-/**
- * @ingroup sys_nonstandard
- * lwIP default implementation for strnstr() non-standard function.
- * This can be \#defined to strnstr() depending on your platform port.
- */
-char *
-lwip_strnstr(const char *buffer, const char *token, size_t n)
-{
-  const char *p;
-  size_t tokenlen = strlen(token);
-  if (tokenlen == 0) {
-    return LWIP_CONST_CAST(char *, buffer);
-  }
-  for (p = buffer; *p && (p + tokenlen <= buffer + n); p++) {
-    if ((*p == *token) && (strncmp(p, token, tokenlen) == 0)) {
-      return LWIP_CONST_CAST(char *, p);
-    }
-  }
-  return NULL;
-}
-#endif
-
 #ifndef lwip_stricmp
 /**
  * @ingroup sys_nonstandard
@@ -125,13 +102,16 @@ lwip_strnstr(const char *buffer, const char *token, size_t n)
  * This can be \#defined to stricmp() depending on your platform port.
  */
 int
-lwip_stricmp(const char *str1, const char *str2)
+lwip_stricmp(sstring str1, sstring str2)
 {
   char c1, c2;
+  size_t len = str1.len;
 
-  do {
-    c1 = *str1++;
-    c2 = *str2++;
+  if (len != str2.len)
+      return (len - str2.len);
+  while (len--) {
+    c1 = *str1.ptr++;
+    c2 = *str2.ptr++;
     if (c1 != c2) {
       char c1_upc = c1 | 0x20;
       if ((c1_upc >= 'a') && (c1_upc <= 'z')) {
@@ -148,7 +128,7 @@ lwip_stricmp(const char *str1, const char *str2)
         return 1;
       }
     }
-  } while (c1 != 0);
+  };
   return 0;
 }
 #endif

--- a/src/core/ip.c
+++ b/src/core/ip.c
@@ -95,13 +95,13 @@ char *ipaddr_ntoa(const ip_addr_t *addr)
  * @param addr ip address in network order to convert
  * @param buf target buffer where the string is stored
  * @param buflen length of buf
- * @return either pointer to buf which now holds the ASCII
- *         representation of addr or NULL if buf was too small
+ * @return either the string length of the ASCII
+ *         representation of addr or 0 if buf was too small
  */
-char *ipaddr_ntoa_r(const ip_addr_t *addr, char *buf, int buflen)
+int ipaddr_ntoa_r(const ip_addr_t *addr, char *buf, int buflen)
 {
   if (addr == NULL) {
-    return NULL;
+    return 0;
   }
   if (IP_IS_V6(addr)) {
     return ip6addr_ntoa_r(ip_2_ip6(addr), buf, buflen);
@@ -120,29 +120,26 @@ char *ipaddr_ntoa_r(const ip_addr_t *addr, char *buf, int buflen)
  * @return 1 on success, 0 on error
  */
 int
-ipaddr_aton(const char *cp, ip_addr_t *addr)
+ipaddr_aton(sstring cp, ip_addr_t *addr)
 {
-  if (cp != NULL) {
-    const char *c;
-    for (c = cp; *c != 0; c++) {
-      if (*c == ':') {
-        /* contains a colon: IPv6 address */
-        if (addr) {
-          IP_SET_TYPE_VAL(*addr, IPADDR_TYPE_V6);
-        }
-        return ip6addr_aton(cp, ip_2_ip6(addr));
-      } else if (*c == '.') {
-        /* contains a dot: IPv4 address */
-        break;
+  for (bytes i = 0; i < cp.len; i++) {
+    const char c = cp.ptr[i];
+    if (c == ':') {
+      /* contains a colon: IPv6 address */
+      if (addr) {
+        IP_SET_TYPE_VAL(*addr, IPADDR_TYPE_V6);
       }
+      return ip6addr_aton(cp, ip_2_ip6(addr));
+    } else if (c == '.') {
+      /* contains a dot: IPv4 address */
+      break;
     }
-    /* call ip4addr_aton as fallback or if IPv4 was found */
-    if (addr) {
-      IP_SET_TYPE_VAL(*addr, IPADDR_TYPE_V4);
-    }
-    return ip4addr_aton(cp, ip_2_ip4(addr));
   }
-  return 0;
+  /* call ip4addr_aton as fallback or if IPv4 was found */
+  if (addr) {
+    IP_SET_TYPE_VAL(*addr, IPADDR_TYPE_V4);
+  }
+  return ip4addr_aton(cp, ip_2_ip4(addr));
 }
 
 /**

--- a/src/core/ipv4/dhcp.c
+++ b/src/core/ipv4/dhcp.c
@@ -1504,11 +1504,11 @@ dhcp_option_long(u16_t options_out_len, u8_t *options, u32_t value)
 static u16_t
 dhcp_option_hostname(u16_t options_out_len, u8_t *options, struct netif *netif)
 {
-  if (netif->hostname != NULL) {
-    size_t namelen = strlen(netif->hostname);
+  if (!sstring_is_null(netif->hostname)) {
+    size_t namelen = netif->hostname.len;
     if (namelen > 0) {
       size_t len;
-      const char *p = netif->hostname;
+      const char *p = netif->hostname.ptr;
       /* Shrink len to available bytes (need 2 bytes for OPTION_HOSTNAME
          and 1 byte for trailer) */
       size_t available = DHCP_OPTIONS_LEN - options_out_len - 3;

--- a/src/core/ipv4/etharp.c
+++ b/src/core/ipv4/etharp.c
@@ -215,7 +215,8 @@ etharp_tmr(void)
            (arp_table[i].ctime >= ARP_MAXPENDING))) {
         /* pending or stable entry has become old! */
         LWIP_DEBUGF(ETHARP_DEBUG, ("etharp_timer: expired %s entry %d.\n",
-                                   arp_table[i].state >= ETHARP_STATE_STABLE ? "stable" : "pending", i));
+                                   arp_table[i].state >= ETHARP_STATE_STABLE ? ss("stable") : ss("pending"),
+                                   i));
         /* clean up entries that have just been expired */
         etharp_free_entry(i);
       } else if (arp_table[i].state == ETHARP_STATE_STABLE_REREQUESTING_1) {

--- a/src/core/ipv4/igmp.c
+++ b/src/core/ipv4/igmp.c
@@ -278,7 +278,8 @@ igmp_lookup_group(struct netif *ifp, const ip4_addr_t *addr)
     }
   }
 
-  LWIP_DEBUGF(IGMP_DEBUG, ("igmp_lookup_group: %sallocated a new group with address ", (group ? "" : "impossible to ")));
+  LWIP_DEBUGF(IGMP_DEBUG, ("igmp_lookup_group: %sallocated a new group with address ",
+                           (group ? sstring_empty() : ss("impossible to "))));
   ip4_addr_debug_print(IGMP_DEBUG, addr);
   LWIP_DEBUGF(IGMP_DEBUG, (" on if %p\n", (void *)ifp));
 

--- a/src/core/ipv6/dhcp6.c
+++ b/src/core/ipv6/dhcp6.c
@@ -219,7 +219,7 @@ void dhcp6_cleanup(struct netif *netif)
 }
 
 static struct dhcp6*
-dhcp6_get_struct(struct netif *netif, const char *dbg_requester)
+dhcp6_get_struct(struct netif *netif, sstring dbg_requester)
 {
   struct dhcp6 *dhcp6 = netif_dhcp6_data(netif);
   if (dhcp6 == NULL) {
@@ -256,7 +256,7 @@ dhcp6_get_struct(struct netif *netif, const char *dbg_requester)
  * If the state changed, reset the number of tries.
  */
 static void
-dhcp6_set_state(struct dhcp6 *dhcp6, u8_t new_state, const char *dbg_caller)
+dhcp6_set_state(struct dhcp6 *dhcp6, u8_t new_state, sstring dbg_caller)
 {
   LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_STATE, ("DHCPv6 state: %d -> %d (%s)\n",
     dhcp6->state, new_state, dbg_caller));
@@ -489,7 +489,7 @@ dhcp6_solicit(struct netif *netif, struct dhcp6 *dhcp6)
   struct pbuf *p_out;
   u16_t opt_out_len;
 
-  dhcp6_set_state(dhcp6, DHCP6_STATE_SOLICIT, "dhcp6_solicit");
+  dhcp6_set_state(dhcp6, DHCP6_STATE_SOLICIT, ss("dhcp6_solicit"));
   p_out = dhcp6_create_msg(netif, dhcp6, DHCP6_SOLICIT,
     4 + 4 + NETIF_MAX_HWADDR_LEN /* CLIENTID */ + 4 + 2 /* ELAPSED_TIME */ + 4 + 12 /* IA_NA */,
     &opt_out_len);
@@ -567,7 +567,7 @@ dhcp6_request(struct netif *netif, struct dhcp6 *dhcp6, u8_t req_type)
 static void
 dhcp6_request_addr(struct netif *netif, struct dhcp6 *dhcp6)
 {
-  dhcp6_set_state(dhcp6, DHCP6_STATE_REQUESTING_ADDR, "dhcp6_request_addr");
+  dhcp6_set_state(dhcp6, DHCP6_STATE_REQUESTING_ADDR, ss("dhcp6_request_addr"));
   dhcp6_request(netif, dhcp6, DHCP6_REQUEST);
   dhcp6_set_req_timeout(dhcp6, 1, 30);
 }
@@ -575,7 +575,7 @@ dhcp6_request_addr(struct netif *netif, struct dhcp6 *dhcp6)
 static void
 dhcp6_renew(struct netif *netif, struct dhcp6 *dhcp6)
 {
-  dhcp6_set_state(dhcp6, DHCP6_STATE_RENEW, "dhcp6_renew");
+  dhcp6_set_state(dhcp6, DHCP6_STATE_RENEW, ss("dhcp6_renew"));
   dhcp6_request(netif, dhcp6, DHCP6_RENEW);
   dhcp6_set_req_timeout(dhcp6, 10, 600);
 }
@@ -584,7 +584,7 @@ static void
 dhcp6_rebind(struct netif *netif, struct dhcp6 *dhcp6)
 {
   dhcp6->server_id_len = 0; /* forget any known server */
-  dhcp6_set_state(dhcp6, DHCP6_STATE_REBIND, "dhcp6_rebind");
+  dhcp6_set_state(dhcp6, DHCP6_STATE_REBIND, ss("dhcp6_rebind"));
   dhcp6_request(netif, dhcp6, DHCP6_REBIND);
   dhcp6_set_req_timeout(dhcp6, 10, 600);
 }
@@ -776,7 +776,7 @@ dhcp6_handle_reply(struct netif *netif, struct pbuf *p_msg_in)
       LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_WARNING,
         ("dhcp6_handle_reply: could not add IP address (%d)\n", (int)err));
     }
-    dhcp6_set_state(dhcp6, DHCP6_STATE_STATEFUL_IDLE, "dhcp6_handle_reply");
+    dhcp6_set_state(dhcp6, DHCP6_STATE_STATEFUL_IDLE, ss("dhcp6_handle_reply"));
   }
 }
 
@@ -819,7 +819,7 @@ dhcp6_enable_stateful(struct netif *netif)
 #if LWIP_IPV6_DHCP6_STATEFUL
   err_t err;
   SYS_ARCH_LOCK(&dhcp6_mutex);
-  struct dhcp6 *dhcp6 = dhcp6_get_struct(netif, "dhcp6_enable_stateful");
+  struct dhcp6 *dhcp6 = dhcp6_get_struct(netif, ss("dhcp6_enable_stateful"));
   LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE,
     ("dhcp6_enable_stateful(%c%c%"U16_F")\n", netif->name[0], netif->name[1], (u16_t)netif->num));
   if (dhcp6 == NULL) {
@@ -866,7 +866,7 @@ dhcp6_enable_stateless(struct netif *netif)
   LWIP_DEBUGF(DHCP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_STATE, ("dhcp6_enable_stateless(netif=%p) %c%c%"U16_F"\n", (void *)netif, netif->name[0], netif->name[1], (u16_t)netif->num));
 
   SYS_ARCH_LOCK(&dhcp6_mutex);
-  dhcp6 = dhcp6_get_struct(netif, "dhcp6_enable_stateless()");
+  dhcp6 = dhcp6_get_struct(netif, ss("dhcp6_enable_stateless"));
   if (dhcp6 == NULL) {
     err = ERR_MEM;
     goto out;
@@ -881,7 +881,7 @@ dhcp6_enable_stateless(struct netif *netif)
     LWIP_DEBUGF(DHCP_DEBUG | LWIP_DBG_TRACE, ("dhcp6_enable_stateless(): switching from stateful to stateless DHCPv6"));
   }
   LWIP_DEBUGF(DHCP_DEBUG | LWIP_DBG_TRACE, ("dhcp6_enable_stateless(): stateless DHCPv6 enabled\n"));
-  dhcp6_set_state(dhcp6, DHCP6_STATE_STATELESS_IDLE, "dhcp6_enable_stateless");
+  dhcp6_set_state(dhcp6, DHCP6_STATE_STATELESS_IDLE, ss("dhcp6_enable_stateless"));
   err = ERR_OK;
 out:
   SYS_ARCH_UNLOCK(&dhcp6_mutex);
@@ -906,8 +906,8 @@ dhcp6_disable(struct netif *netif)
   if (dhcp6 != NULL) {
     if (dhcp6->state != DHCP6_STATE_OFF) {
       LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE, ("dhcp6_disable(): DHCPv6 disabled (old state: %s)\n",
-        (dhcp6_stateless_enabled(dhcp6) ? "stateless" : "stateful")));
-      dhcp6_set_state(dhcp6, DHCP6_STATE_OFF, "dhcp6_disable");
+        (dhcp6_stateless_enabled(dhcp6) ? ss("stateless") : ss("stateful"))));
+      dhcp6_set_state(dhcp6, DHCP6_STATE_OFF, ss("dhcp6_disable"));
       if (dhcp6->pcb_allocated != 0) {
         dhcp6_dec_pcb_refcount(); /* free DHCPv6 PCB if not needed any more */
         dhcp6->pcb_allocated = 0;
@@ -955,7 +955,7 @@ dhcp6_information_request(struct netif *netif, struct dhcp6 *dhcp6)
   } else {
     LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_SERIOUS, ("dhcp6_information_request: could not allocate DHCP6 request\n"));
   }
-  dhcp6_set_state(dhcp6, DHCP6_STATE_REQUESTING_CONFIG, "dhcp6_information_request");
+  dhcp6_set_state(dhcp6, DHCP6_STATE_REQUESTING_CONFIG, ss("dhcp6_information_request"));
   if (dhcp6->tries < 255) {
     dhcp6->tries++;
   }
@@ -979,7 +979,7 @@ dhcp6_abort_config_request(struct dhcp6 *dhcp6)
 {
   if (dhcp6->state == DHCP6_STATE_REQUESTING_CONFIG) {
     /* abort running request */
-    dhcp6_set_state(dhcp6, DHCP6_STATE_STATELESS_IDLE, "dhcp6_abort_config_request");
+    dhcp6_set_state(dhcp6, DHCP6_STATE_STATELESS_IDLE, ss("dhcp6_abort_config_request"));
   }
 }
 
@@ -1197,8 +1197,11 @@ dhcp6_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, struct ip_globals *ip
 
   LWIP_ERROR("invalid server address type", IP_IS_V6(addr), goto free_pbuf_and_return;);
 
+#ifdef LWIP_DEBUG
+  char addr_str[IP6ADDR_STRLEN_MAX];
   LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE, ("dhcp6_recv(pbuf = %p) from DHCPv6 server %s port %"U16_F"\n", (void *)p,
-    ipaddr_ntoa(addr), port));
+    isstring(addr_str, ipaddr_ntoa_r(addr, addr_str, sizeof(addr_str))), port));
+#endif
   LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE, ("pbuf->len = %"U16_F"\n", p->len));
   LWIP_DEBUGF(DHCP6_DEBUG | LWIP_DBG_TRACE, ("pbuf->tot_len = %"U16_F"\n", p->tot_len));
   /* prevent warnings about unused arguments */
@@ -1235,7 +1238,7 @@ dhcp6_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, struct ip_globals *ip
 #if LWIP_IPV6_DHCP6_STATELESS
     /* in info-requesting state? */
     if (dhcp6->state == DHCP6_STATE_REQUESTING_CONFIG) {
-      dhcp6_set_state(dhcp6, DHCP6_STATE_STATELESS_IDLE, "dhcp6_recv");
+      dhcp6_set_state(dhcp6, DHCP6_STATE_STATELESS_IDLE, ss("dhcp6_recv"));
       dhcp6_handle_config_reply(netif, p);
     } else
 #endif /* LWIP_IPV6_DHCP6_STATELESS */

--- a/src/core/mem.c
+++ b/src/core/mem.c
@@ -94,7 +94,7 @@
  * @param descr2 description of the element source shown on error
  */
 void
-mem_overflow_check_raw(void *p, size_t size, const char *descr1, const char *descr2)
+mem_overflow_check_raw(void *p, size_t size, sstring descr1, sstring descr2)
 {
 #if MEM_SANITY_REGION_AFTER_ALIGNED || MEM_SANITY_REGION_BEFORE_ALIGNED
   u16_t k;

--- a/src/core/pbuf.c
+++ b/src/core/pbuf.c
@@ -335,7 +335,7 @@ pbuf_alloc_reference(void *payload, u16_t length, pbuf_type type)
   if (p == NULL) {
     LWIP_DEBUGF(PBUF_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
                 ("pbuf_alloc_reference: Could not allocate MEMP_PBUF for PBUF_%s.\n",
-                 (type == PBUF_ROM) ? "ROM" : "REF"));
+                 (type == PBUF_ROM) ? ss("ROM") : ss("REF")));
     return NULL;
   }
   pbuf_init_alloced_pbuf(p, payload, length, length, type, 0);
@@ -1482,29 +1482,4 @@ pbuf_memfind(const struct pbuf *p, const void *mem, u16_t mem_len, u16_t start_o
     }
   }
   return 0xFFFF;
-}
-
-/**
- * Find occurrence of substr with length substr_len in pbuf p, start at offset
- * start_offset
- * WARNING: in contrast to strstr(), this one does not stop at the first \0 in
- * the pbuf/source string!
- *
- * @param p pbuf to search, maximum length is 0xFFFE since 0xFFFF is used as
- *        return value 'not found'
- * @param substr string to search for in p, maximum length is 0xFFFE
- * @return 0xFFFF if substr was not found in p or the index where it was found
- */
-u16_t
-pbuf_strstr(const struct pbuf *p, const char *substr)
-{
-  size_t substr_len;
-  if ((substr == NULL) || (substr[0] == 0) || (p->tot_len == 0xFFFF)) {
-    return 0xFFFF;
-  }
-  substr_len = strlen(substr);
-  if (substr_len >= 0xFFFF) {
-    return 0xFFFF;
-  }
-  return pbuf_memfind(p, substr, (u16_t)substr_len, 0);
 }

--- a/src/core/stats.c
+++ b/src/core/stats.c
@@ -61,7 +61,7 @@ stats_init(void)
 
 #if LWIP_STATS_DISPLAY
 void
-stats_display_proto(struct stats_proto *proto, const char *name)
+stats_display_proto(struct stats_proto *proto, sstring name)
 {
   LWIP_PLATFORM_DIAG(("\n%s\n\t", name));
   LWIP_PLATFORM_DIAG(("xmit: %"STAT_COUNTER_F"\n\t", proto->xmit));
@@ -80,7 +80,7 @@ stats_display_proto(struct stats_proto *proto, const char *name)
 
 #if IGMP_STATS || MLD6_STATS
 void
-stats_display_igmp(struct stats_igmp *igmp, const char *name)
+stats_display_igmp(struct stats_igmp *igmp, sstring name)
 {
   LWIP_PLATFORM_DIAG(("\n%s\n\t", name));
   LWIP_PLATFORM_DIAG(("xmit: %"STAT_COUNTER_F"\n\t", igmp->xmit));
@@ -102,7 +102,7 @@ stats_display_igmp(struct stats_igmp *igmp, const char *name)
 
 #if MEM_STATS || MEMP_STATS
 void
-stats_display_mem(struct stats_mem *mem, const char *name)
+stats_display_mem(struct stats_mem *mem, sstring name)
 {
   LWIP_PLATFORM_DIAG(("\nMEM %s\n\t", name));
   LWIP_PLATFORM_DIAG(("avail: %"MEM_SIZE_F"\n\t", mem->avail));

--- a/src/core/tcp.c
+++ b/src/core/tcp.c
@@ -141,18 +141,18 @@
 #define INITIAL_MSS TCP_MSS
 #endif
 
-static const char *const tcp_state_str[] = {
-  "CLOSED",
-  "LISTEN",
-  "SYN_SENT",
-  "SYN_RCVD",
-  "ESTABLISHED",
-  "FIN_WAIT_1",
-  "FIN_WAIT_2",
-  "CLOSE_WAIT",
-  "CLOSING",
-  "LAST_ACK",
-  "TIME_WAIT"
+static const sstring tcp_state_str[] = {
+  ss_static_init("CLOSED"),
+  ss_static_init("LISTEN"),
+  ss_static_init("SYN_SENT"),
+  ss_static_init("SYN_RCVD"),
+  ss_static_init("ESTABLISHED"),
+  ss_static_init("FIN_WAIT_1"),
+  ss_static_init("FIN_WAIT_2"),
+  ss_static_init("CLOSE_WAIT"),
+  ss_static_init("CLOSING"),
+  ss_static_init("LAST_ACK"),
+  ss_static_init("TIME_WAIT")
 };
 
 /* last local TCP port */
@@ -2445,7 +2445,7 @@ tcp_netif_ip_addr_changed(const ip_addr_t *old_addr, const ip_addr_t *new_addr)
   }
 }
 
-const char *
+sstring
 tcp_debug_state_str(enum tcp_state s)
 {
   return tcp_state_str[s];

--- a/src/core/timeouts.c
+++ b/src/core/timeouts.c
@@ -62,7 +62,7 @@
 #include "lwip/pbuf.h"
 
 #if LWIP_DEBUG_TIMERNAMES
-#define HANDLER(x) x, #x
+#define HANDLER(x) x, ss_static_init(#x)
 #else /* LWIP_DEBUG_TIMERNAMES */
 #define HANDLER(x) x
 #endif /* LWIP_DEBUG_TIMERNAMES */
@@ -178,7 +178,7 @@ tcp_timer_needed(void)
 
 static void
 #if LWIP_DEBUG_TIMERNAMES
-sys_timeout_abs(u32_t abs_time, sys_timeout_handler handler, void *arg, const char *handler_name)
+sys_timeout_abs(u32_t abs_time, sys_timeout_handler handler, void *arg, sstring handler_name)
 #else /* LWIP_DEBUG_TIMERNAMES */
 sys_timeout_abs(u32_t abs_time, sys_timeout_handler handler, void *arg)
 #endif

--- a/src/include/lwip/def.h
+++ b/src/include/lwip/def.h
@@ -138,7 +138,7 @@ int   lwip_strnicmp(const char* str1, const char* str2, size_t len);
 #endif
 #ifndef lwip_stricmp
 /* This can be #defined to stricmp() or strcasecmp() depending on your platform */
-int   lwip_stricmp(const char* str1, const char* str2);
+int   lwip_stricmp(sstring str1, sstring str2);
 #endif
 #ifndef lwip_strnstr
 /* This can be #defined to strnstr() depending on your platform */

--- a/src/include/lwip/dns.h
+++ b/src/include/lwip/dns.h
@@ -100,15 +100,15 @@ extern const ip_addr_t dns_mquery_v6group;
  *        or NULL if the name could not be found (or on any other error).
  * @param callback_arg a user-specified callback argument passed to dns_gethostbyname
 */
-typedef void (*dns_found_callback)(const char *name, const ip_addr_t *ipaddr, void *callback_arg);
+typedef void (*dns_found_callback)(sstring name, const ip_addr_t *ipaddr, void *callback_arg);
 
 void             dns_init(void);
 void             dns_tmr(void);
 void             dns_setserver(u8_t numdns, const ip_addr_t *dnsserver);
 const ip_addr_t* dns_getserver(u8_t numdns);
-err_t            dns_gethostbyname(const char *hostname, ip_addr_t *addr,
+err_t            dns_gethostbyname(sstring hostname, ip_addr_t *addr,
                                    dns_found_callback found, void *callback_arg);
-err_t            dns_gethostbyname_addrtype(const char *hostname, ip_addr_t *addr,
+err_t            dns_gethostbyname_addrtype(sstring hostname, ip_addr_t *addr,
                                    dns_found_callback found, void *callback_arg,
                                    u8_t dns_addrtype);
 

--- a/src/include/lwip/err.h
+++ b/src/include/lwip/err.h
@@ -101,9 +101,9 @@ typedef s8_t err_t;
  */
 
 #ifdef LWIP_DEBUG
-extern const char *lwip_strerr(err_t err);
+extern sstring lwip_strerr(err_t err);
 #else
-#define lwip_strerr(x) ""
+#define lwip_strerr(x) sstring_empty()
 #endif /* LWIP_DEBUG */
 
 #if !NO_SYS

--- a/src/include/lwip/ip4_addr.h
+++ b/src/include/lwip/ip4_addr.h
@@ -201,11 +201,11 @@ u8_t ip4_addr_netmask_valid(u32_t netmask);
 /** For backwards compatibility */
 #define ip_ntoa(ipaddr)  ipaddr_ntoa(ipaddr)
 
-u32_t ipaddr_addr(const char *cp);
-int ip4addr_aton(const char *cp, ip4_addr_t *addr);
+u32_t ipaddr_addr(sstring cp);
+int ip4addr_aton(sstring cp, ip4_addr_t *addr);
 /** returns ptr to static buffer; not reentrant! */
 char *ip4addr_ntoa(const ip4_addr_t *addr);
-char *ip4addr_ntoa_r(const ip4_addr_t *addr, char *buf, int buflen);
+int ip4addr_ntoa_r(const ip4_addr_t *addr, char *buf, int buflen);
 
 #ifdef __cplusplus
 }

--- a/src/include/lwip/ip6_addr.h
+++ b/src/include/lwip/ip6_addr.h
@@ -336,10 +336,10 @@ typedef struct ip6_addr ip6_addr_t;
 
 #define IP6ADDR_STRLEN_MAX    46
 
-int ip6addr_aton(const char *cp, ip6_addr_t *addr);
+int ip6addr_aton(sstring cp, ip6_addr_t *addr);
 /** returns ptr to static buffer; not reentrant! */
 char *ip6addr_ntoa(const ip6_addr_t *addr);
-char *ip6addr_ntoa_r(const ip6_addr_t *addr, char *buf, int buflen);
+int ip6addr_ntoa_r(const ip6_addr_t *addr, char *buf, int buflen);
 
 
 

--- a/src/include/lwip/ip_addr.h
+++ b/src/include/lwip/ip_addr.h
@@ -237,8 +237,8 @@ extern const ip_addr_t ip_addr_any_type;
   ip6_addr_debug_print_val(debug, *ip_2_ip6(&(ipaddr))); } else { \
   ip4_addr_debug_print_val(debug, *ip_2_ip4(&(ipaddr))); }}while(0)
 char *ipaddr_ntoa(const ip_addr_t *addr);
-char *ipaddr_ntoa_r(const ip_addr_t *addr, char *buf, int buflen);
-int ipaddr_aton(const char *cp, ip_addr_t *addr);
+int ipaddr_ntoa_r(const ip_addr_t *addr, char *buf, int buflen);
+int ipaddr_aton(sstring cp, ip_addr_t *addr);
 
 /** @ingroup ipaddr */
 #define IPADDR_STRLEN_MAX   IP6ADDR_STRLEN_MAX

--- a/src/include/lwip/netif.h
+++ b/src/include/lwip/netif.h
@@ -325,8 +325,8 @@ struct netif {
   void* client_data[LWIP_NETIF_CLIENT_DATA_INDEX_MAX + LWIP_NUM_NETIF_CLIENT_DATA];
 #endif
 #if LWIP_NETIF_HOSTNAME
-  /* the hostname for this netif, NULL is a valid value */
-  const char*  hostname;
+  /* the hostname for this netif, an empty string is a valid value */
+  sstring hostname;
 #endif /* LWIP_NETIF_HOSTNAME */
 #if LWIP_CHECKSUM_CTRL_PER_NETIF
   u16_t chksum_flags;
@@ -419,7 +419,7 @@ void netif_remove(struct netif * netif);
    "et0", where the first two letters are the "name" field in the
    netif structure, and the digit is in the num field in the same
    structure. */
-struct netif *netif_find(const char *name);
+struct netif *netif_find(sstring name);
 
 void netif_iterate(u8_t (*handler)(struct netif *n, void *priv), void *priv);
 

--- a/src/include/lwip/priv/memp_priv.h
+++ b/src/include/lwip/priv/memp_priv.h
@@ -108,7 +108,7 @@ typedef enum {
 struct memp_desc {
 #if defined(LWIP_DEBUG) || MEMP_OVERFLOW_CHECK || LWIP_STATS_DISPLAY
   /** Textual description */
-  const char *desc;
+  sstring desc;
 #endif /* LWIP_DEBUG || MEMP_OVERFLOW_CHECK || LWIP_STATS_DISPLAY */
 #if MEMP_STATS
   /** Statistics */
@@ -131,7 +131,7 @@ struct memp_desc {
 };
 
 #if defined(LWIP_DEBUG) || MEMP_OVERFLOW_CHECK || LWIP_STATS_DISPLAY
-#define DECLARE_LWIP_MEMPOOL_DESC(desc) (desc),
+#define DECLARE_LWIP_MEMPOOL_DESC(desc) ss_static_init(desc),
 #else
 #define DECLARE_LWIP_MEMPOOL_DESC(desc)
 #endif

--- a/src/include/lwip/stats.h
+++ b/src/include/lwip/stats.h
@@ -97,7 +97,7 @@ struct stats_igmp {
 /** Memory stats */
 struct stats_mem {
 #if defined(LWIP_DEBUG) || LWIP_STATS_DISPLAY
-  const char *name;
+  sstring name;
 #endif /* defined(LWIP_DEBUG) || LWIP_STATS_DISPLAY */
   STAT_COUNTER err;
   mem_size_t avail;
@@ -323,7 +323,7 @@ void stats_init(void);
 
 #if TCP_STATS
 #define TCP_STATS_INC(x) STATS_INC(x)
-#define TCP_STATS_DISPLAY() stats_display_proto(&lwip_stats.tcp, "TCP")
+#define TCP_STATS_DISPLAY() stats_display_proto(&lwip_stats.tcp, ss("TCP"))
 #else
 #define TCP_STATS_INC(x)
 #define TCP_STATS_DISPLAY()
@@ -331,7 +331,7 @@ void stats_init(void);
 
 #if UDP_STATS
 #define UDP_STATS_INC(x) STATS_INC(x)
-#define UDP_STATS_DISPLAY() stats_display_proto(&lwip_stats.udp, "UDP")
+#define UDP_STATS_DISPLAY() stats_display_proto(&lwip_stats.udp, ss("UDP"))
 #else
 #define UDP_STATS_INC(x)
 #define UDP_STATS_DISPLAY()
@@ -339,7 +339,7 @@ void stats_init(void);
 
 #if ICMP_STATS
 #define ICMP_STATS_INC(x) STATS_INC(x)
-#define ICMP_STATS_DISPLAY() stats_display_proto(&lwip_stats.icmp, "ICMP")
+#define ICMP_STATS_DISPLAY() stats_display_proto(&lwip_stats.icmp, ss("ICMP"))
 #else
 #define ICMP_STATS_INC(x)
 #define ICMP_STATS_DISPLAY()
@@ -347,7 +347,7 @@ void stats_init(void);
 
 #if IGMP_STATS
 #define IGMP_STATS_INC(x) STATS_INC(x)
-#define IGMP_STATS_DISPLAY() stats_display_igmp(&lwip_stats.igmp, "IGMP")
+#define IGMP_STATS_DISPLAY() stats_display_igmp(&lwip_stats.igmp, ss("IGMP"))
 #else
 #define IGMP_STATS_INC(x)
 #define IGMP_STATS_DISPLAY()
@@ -355,7 +355,7 @@ void stats_init(void);
 
 #if IP_STATS
 #define IP_STATS_INC(x) STATS_INC(x)
-#define IP_STATS_DISPLAY() stats_display_proto(&lwip_stats.ip, "IP")
+#define IP_STATS_DISPLAY() stats_display_proto(&lwip_stats.ip, ss("IP"))
 #else
 #define IP_STATS_INC(x)
 #define IP_STATS_DISPLAY()
@@ -363,7 +363,7 @@ void stats_init(void);
 
 #if IPFRAG_STATS
 #define IPFRAG_STATS_INC(x) STATS_INC(x)
-#define IPFRAG_STATS_DISPLAY() stats_display_proto(&lwip_stats.ip_frag, "IP_FRAG")
+#define IPFRAG_STATS_DISPLAY() stats_display_proto(&lwip_stats.ip_frag, ss("IP_FRAG"))
 #else
 #define IPFRAG_STATS_INC(x)
 #define IPFRAG_STATS_DISPLAY()
@@ -371,7 +371,7 @@ void stats_init(void);
 
 #if ETHARP_STATS
 #define ETHARP_STATS_INC(x) STATS_INC(x)
-#define ETHARP_STATS_DISPLAY() stats_display_proto(&lwip_stats.etharp, "ETHARP")
+#define ETHARP_STATS_DISPLAY() stats_display_proto(&lwip_stats.etharp, ss("ETHARP"))
 #else
 #define ETHARP_STATS_INC(x)
 #define ETHARP_STATS_DISPLAY()
@@ -379,7 +379,7 @@ void stats_init(void);
 
 #if LINK_STATS
 #define LINK_STATS_INC(x) STATS_INC(x)
-#define LINK_STATS_DISPLAY() stats_display_proto(&lwip_stats.link, "LINK")
+#define LINK_STATS_DISPLAY() stats_display_proto(&lwip_stats.link, ss("LINK"))
 #else
 #define LINK_STATS_INC(x)
 #define LINK_STATS_DISPLAY()
@@ -390,7 +390,7 @@ void stats_init(void);
 #define MEM_STATS_INC(x) STATS_INC(mem.x)
 #define MEM_STATS_INC_USED(x, y) STATS_INC_USED(mem, y, mem_size_t)
 #define MEM_STATS_DEC_USED(x, y) lwip_stats.mem.x = (mem_size_t)((lwip_stats.mem.x) - (y))
-#define MEM_STATS_DISPLAY() stats_display_mem(&lwip_stats.mem, "HEAP")
+#define MEM_STATS_DISPLAY() stats_display_mem(&lwip_stats.mem, ss("HEAP"))
 #else
 #define MEM_STATS_AVAIL(x, y)
 #define MEM_STATS_INC(x)
@@ -423,7 +423,7 @@ void stats_init(void);
 
 #if IP6_STATS
 #define IP6_STATS_INC(x) STATS_INC(x)
-#define IP6_STATS_DISPLAY() stats_display_proto(&lwip_stats.ip6, "IPv6")
+#define IP6_STATS_DISPLAY() stats_display_proto(&lwip_stats.ip6, ss("IPv6"))
 #else
 #define IP6_STATS_INC(x)
 #define IP6_STATS_DISPLAY()
@@ -431,7 +431,7 @@ void stats_init(void);
 
 #if ICMP6_STATS
 #define ICMP6_STATS_INC(x) STATS_INC(x)
-#define ICMP6_STATS_DISPLAY() stats_display_proto(&lwip_stats.icmp6, "ICMPv6")
+#define ICMP6_STATS_DISPLAY() stats_display_proto(&lwip_stats.icmp6, ss("ICMPv6"))
 #else
 #define ICMP6_STATS_INC(x)
 #define ICMP6_STATS_DISPLAY()
@@ -439,7 +439,7 @@ void stats_init(void);
 
 #if IP6_FRAG_STATS
 #define IP6_FRAG_STATS_INC(x) STATS_INC(x)
-#define IP6_FRAG_STATS_DISPLAY() stats_display_proto(&lwip_stats.ip6_frag, "IPv6 FRAG")
+#define IP6_FRAG_STATS_DISPLAY() stats_display_proto(&lwip_stats.ip6_frag, ss("IPv6 FRAG"))
 #else
 #define IP6_FRAG_STATS_INC(x)
 #define IP6_FRAG_STATS_DISPLAY()
@@ -447,7 +447,7 @@ void stats_init(void);
 
 #if MLD6_STATS
 #define MLD6_STATS_INC(x) STATS_INC(x)
-#define MLD6_STATS_DISPLAY() stats_display_igmp(&lwip_stats.mld6, "MLDv1")
+#define MLD6_STATS_DISPLAY() stats_display_igmp(&lwip_stats.mld6, ss("MLDv1"))
 #else
 #define MLD6_STATS_INC(x)
 #define MLD6_STATS_DISPLAY()
@@ -455,7 +455,7 @@ void stats_init(void);
 
 #if ND6_STATS
 #define ND6_STATS_INC(x) STATS_INC(x)
-#define ND6_STATS_DISPLAY() stats_display_proto(&lwip_stats.nd6, "ND")
+#define ND6_STATS_DISPLAY() stats_display_proto(&lwip_stats.nd6, ss("ND"))
 #else
 #define ND6_STATS_INC(x)
 #define ND6_STATS_DISPLAY()
@@ -470,9 +470,9 @@ void stats_init(void);
 /* Display of statistics */
 #if LWIP_STATS_DISPLAY
 void stats_display(void);
-void stats_display_proto(struct stats_proto *proto, const char *name);
-void stats_display_igmp(struct stats_igmp *igmp, const char *name);
-void stats_display_mem(struct stats_mem *mem, const char *name);
+void stats_display_proto(struct stats_proto *proto, sstring name);
+void stats_display_igmp(struct stats_igmp *igmp, sstring name);
+void stats_display_mem(struct stats_mem *mem, sstring name);
 void stats_display_memp(struct stats_mem *mem, int index);
 void stats_display_sys(struct stats_sys *sys);
 #else /* LWIP_STATS_DISPLAY */

--- a/src/include/lwip/tcpbase.h
+++ b/src/include/lwip/tcpbase.h
@@ -77,7 +77,7 @@ enum tcp_state {
 #define TCP_PRIO_NORMAL 64
 #define TCP_PRIO_MAX    127
 
-const char* tcp_debug_state_str(enum tcp_state s);
+sstring tcp_debug_state_str(enum tcp_state s);
 
 #ifdef __cplusplus
 }

--- a/src/include/lwip/timeouts.h
+++ b/src/include/lwip/timeouts.h
@@ -71,7 +71,7 @@ struct lwip_cyclic_timer {
   u32_t interval_ms;
   lwip_cyclic_timer_handler handler;
 #if LWIP_DEBUG_TIMERNAMES
-  const char* handler_name;
+  sstring handler_name;
 #endif /* LWIP_DEBUG_TIMERNAMES */
 };
 
@@ -96,7 +96,7 @@ struct sys_timeo {
   sys_timeout_handler h;
   void *arg;
 #if LWIP_DEBUG_TIMERNAMES
-  const char* handler_name;
+  sstring handler_name;
 #endif /* LWIP_DEBUG_TIMERNAMES */
 };
 


### PR DESCRIPTION
This changeset adapts the lwIP code to the change in the Nanos kernel that removes the use of string functions that access string memory without a limit (i.e. that rely on the presence of a string terminator to determine the end of a string).