### PR TITLE
Cyclic timers: dynamically enable and disable MLD6 timer

### DIFF
--- a/src/include/lwip/priv/mld6_priv.h
+++ b/src/include/lwip/priv/mld6_priv.h
@@ -1,0 +1,56 @@
+/**
+ * @file
+ *
+ * Multicast listener discovery for IPv6.
+ */
+
+/*
+ * Copyright (c) 2024 NanoVMs Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ */
+
+#ifndef LWIP_HDR_MLD6_PRIV_H
+#define LWIP_HDR_MLD6_PRIV_H
+
+#include "lwip/opt.h"
+
+#if LWIP_IPV6_MLD
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void mld6_timer_needed(void);
+u8_t mld6_timer_is_needed(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LWIP_IPV6_MLD */
+
+#endif /* LWIP_HDR_MLD6_PRIV_H */


### PR DESCRIPTION
Similarly to the TCP timer, the MLD6 timer does not always need to be dispatched. Dispatching an unneeded timer causes useless CPU usage, especially for high-frequency timers (the MLD6 timer period is 100 ms).
In order to decrease CPU usage when the system is idle, this change removes the MLD6 timer from the list of static timers and adds dynamic enablement of the timer.