### PR TITLE
IPv4: add support for setting DONT_FRAGMENT flag in output packets

### DIFF
--- a/src/core/ipv4/icmp.c
+++ b/src/core/ipv4/icmp.c
@@ -248,7 +248,7 @@ icmp_input(struct pbuf *p, struct ip_globals *ip_data)
 
         /* send an ICMP packet */
         ret = ip4_output_if(p, src, LWIP_IP_HDRINCL,
-                            ICMP_TTL, 0, IP_PROTO_ICMP, ip_data->current_input_netif);
+                            ICMP_TTL, 0, IP_PROTO_ICMP, false, ip_data->current_input_netif);
         if (ret != ERR_OK) {
           LWIP_DEBUGF(ICMP_DEBUG, ("icmp_input: ip_output_if returned an error: %s\n", lwip_strerr(ret)));
         }
@@ -396,7 +396,7 @@ icmp_send_response(struct pbuf *p, u8_t type, u8_t code)
     }
 #endif
     ICMP_STATS_INC(icmp.xmit);
-    ip4_output_if(q, NULL, &iphdr_src, ICMP_TTL, 0, IP_PROTO_ICMP, netif);
+    ip4_output_if(q, NULL, &iphdr_src, ICMP_TTL, 0, IP_PROTO_ICMP, false, netif);
     netif_unref(netif);
   }
   pbuf_free(q);

--- a/src/core/tcp.c
+++ b/src/core/tcp.c
@@ -928,6 +928,7 @@ tcp_listen_with_backlog_and_err(struct tcp_pcb *pcb, u8_t backlog, err_t *err)
   lpcb->netif_idx = NETIF_NO_INDEX;
   lpcb->ttl = pcb->ttl;
   lpcb->tos = pcb->tos;
+  lpcb->pmtudisc = pcb->pmtudisc;
 #if LWIP_IPV4 && LWIP_IPV6
   IP_SET_TYPE_VAL(lpcb->remote_ip, pcb->local_ip.type);
 #endif /* LWIP_IPV4 && LWIP_IPV6 */

--- a/src/core/tcp_out.c
+++ b/src/core/tcp_out.c
@@ -1602,7 +1602,7 @@ tcp_output_segment(struct tcp_seg *seg, struct tcp_pcb *pcb, struct netif *netif
 
   NETIF_SET_HINTS(netif, &(pcb->netif_hints));
   err = ip_output_if(seg->p, &pcb->local_ip, &pcb->remote_ip, pcb->ttl,
-                     pcb->tos, IP_PROTO_TCP, netif);
+                     pcb->tos, IP_PROTO_TCP, ip_dont_fragment(pcb), netif);
   NETIF_RESET_HINTS(netif);
 
 #if TCP_CHECKSUM_ON_COPY
@@ -1945,7 +1945,7 @@ tcp_output_control_segment(const struct tcp_pcb *pcb, struct pbuf *p,
       tos = 0;
     }
     TCP_STATS_INC(tcp.xmit);
-    err = ip_output_if(p, src, dst, ttl, tos, IP_PROTO_TCP, netif);
+    err = ip_output_if(p, src, dst, ttl, tos, IP_PROTO_TCP, false, netif);
     NETIF_RESET_HINTS(netif);
     netif_unref(netif);
   }

--- a/src/core/udp.c
+++ b/src/core/udp.c
@@ -906,7 +906,7 @@ udp_sendto_if_src_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *d
   LWIP_DEBUGF(UDP_DEBUG, ("udp_send: ip_output_if (,,,,0x%02"X16_F",)\n", (u16_t)ip_proto));
   /* output to IP */
   NETIF_SET_HINTS(netif, &(pcb->netif_hints));
-  err = ip_output_if_src(q, src_ip, dst_ip, ttl, pcb->tos, ip_proto, netif);
+  err = ip_output_if_src(q, src_ip, dst_ip, ttl, pcb->tos, ip_proto, ip_dont_fragment(pcb), netif);
   NETIF_RESET_HINTS(netif);
 
   /* @todo: must this be increased even if error occurred? */

--- a/src/include/lwip/err.h
+++ b/src/include/lwip/err.h
@@ -85,7 +85,9 @@ typedef enum {
 /** Connection closed.       */
   ERR_CLSD       = -15,
 /** Illegal argument.        */
-  ERR_ARG        = -16
+  ERR_ARG        = -16,
+/** Message too long.        */
+  ERR_MSGSIZE    = -17,
 } err_enum_t;
 
 /** Define LWIP_ERR_T in cc.h if you want to use

--- a/src/include/lwip/ip4.h
+++ b/src/include/lwip/ip4.h
@@ -70,21 +70,21 @@ struct netif *ip4_route_src(const ip4_addr_t *src, const ip4_addr_t *dest);
 #endif /* LWIP_IPV4_SRC_ROUTING */
 err_t ip4_input(struct pbuf *p, struct netif *inp);
 err_t ip4_output(struct pbuf *p, const ip4_addr_t *src, const ip4_addr_t *dest,
-       u8_t ttl, u8_t tos, u8_t proto);
+       u8_t ttl, u8_t tos, u8_t proto, boolean df);
 err_t ip4_output_if(struct pbuf *p, const ip4_addr_t *src, const ip4_addr_t *dest,
-       u8_t ttl, u8_t tos, u8_t proto, struct netif *netif);
+       u8_t ttl, u8_t tos, u8_t proto, boolean df, struct netif *netif);
 err_t ip4_output_if_src(struct pbuf *p, const ip4_addr_t *src, const ip4_addr_t *dest,
-       u8_t ttl, u8_t tos, u8_t proto, struct netif *netif);
+       u8_t ttl, u8_t tos, u8_t proto, boolean df, struct netif *netif);
 #if LWIP_NETIF_USE_HINTS
 err_t ip4_output_hinted(struct pbuf *p, const ip4_addr_t *src, const ip4_addr_t *dest,
        u8_t ttl, u8_t tos, u8_t proto, struct netif_hint *netif_hint);
 #endif /* LWIP_NETIF_USE_HINTS */
 #if IP_OPTIONS_SEND
 err_t ip4_output_if_opt(struct pbuf *p, const ip4_addr_t *src, const ip4_addr_t *dest,
-       u8_t ttl, u8_t tos, u8_t proto, struct netif *netif, void *ip_options,
+       u8_t ttl, u8_t tos, u8_t proto, boolean df, struct netif *netif, void *ip_options,
        u16_t optlen);
 err_t ip4_output_if_opt_src(struct pbuf *p, const ip4_addr_t *src, const ip4_addr_t *dest,
-       u8_t ttl, u8_t tos, u8_t proto, struct netif *netif, void *ip_options,
+       u8_t ttl, u8_t tos, u8_t proto, boolean df, struct netif *netif, void *ip_options,
        u16_t optlen);
 #endif /* IP_OPTIONS_SEND */
 


### PR DESCRIPTION
Add a new `pmtudisc` field to the ip_pcb struct to store the path MTU discovery setting for a socket; if the value of this field is IP_PMTUDISC_DO or IP_PMTUDISC_PROBE, the DF flag is set in output IPv4 packets (if a packet is larger than the MTU of the output interface, the packet is not sent and ERR_MSGSIZE is returned); the default value of this field is IP_PMTUDISC_DONT, i.e. the DF flag is not set by default.